### PR TITLE
blocking guarantee, offload, runtime DSL

### DIFF
--- a/core/src/main/scala/io/parapet/core/Channel.scala
+++ b/core/src/main/scala/io/parapet/core/Channel.scala
@@ -25,6 +25,9 @@ class Channel[F[_]](override val ref: ProcessRef = ProcessRef.jdkUUIDRef)(using 
   import Channel.*
   import dsl.*
 
+  private val runtimeDsl = summon[Dsl.RuntimeOps.Aux[F]]
+  import runtimeDsl.*
+
   private var callback: Deferred[F, Try[Event]] = _
   private val debugCallNumber                   = new AtomicInteger()
   private val debugMode                         = false
@@ -79,7 +82,7 @@ class Channel[F[_]](override val ref: ProcessRef = ProcessRef.jdkUUIDRef)(using 
 
   /** Sends `event` to `receiver` and suspends until a response (or failure) arrives.
     *
-    * The implementation acquires the channel's per-process lock for the duration of the call so concurrent senders
+    * The implementation acquires the channel's runtime delivery lock for the duration of the call so concurrent senders
     * queue cleanly.
     *
     * @return
@@ -88,10 +91,10 @@ class Channel[F[_]](override val ref: ProcessRef = ProcessRef.jdkUUIDRef)(using 
     */
   def send(event: Event, receiver: ProcessRef): DslF[F, Try[Event]] =
     for
-      _        <- lock(ref)
+      _        <- lockProcess(ref)
       deferred <- suspend(Deferred[F, Try[Event]]())
       _        <- sendReq(Request(event, deferred, receiver))
-      _        <- unlock(ref)
+      _        <- unlockProcess(ref)
       value    <- suspend(deferred.get)
     yield value
 

--- a/core/src/main/scala/io/parapet/core/Context.scala
+++ b/core/src/main/scala/io/parapet/core/Context.scala
@@ -189,9 +189,12 @@ object Context:
   )(using effect: Effect[F]): F[Context[F]] =
     effect.delay(new Context[F](config, eventStore, eventTransformers))
 
-  /** Pairs a long-running blocking operation with the [[Deferred]] that fires when it completes, used by [[AsyncOps]].
+  /** Pairs a long-running blocking operation with the [[Deferred]] that records how it completed, used by [[AsyncOps]].
     */
-  final case class BlockingOp[F[_]](blockingOperation: EffectFiber[F, Unit], done: Deferred[F, Unit])
+  final case class BlockingOp[F[_]](
+      blockingOperation: EffectFiber[F, Unit],
+      done: Deferred[F, Either[Throwable, Unit]]
+  )
 
   /** Bookkeeping for blocking operations spawned by a single process.
     *
@@ -203,15 +206,21 @@ object Context:
 
     /** Tracks one in-flight blocking operation. Called by the scheduler when entering a `dsl.blocking` region.
       */
-    def add(blockingOperation: EffectFiber[F, Unit], done: Deferred[F, Unit]): F[Unit] =
+    def add(blockingOperation: EffectFiber[F, Unit], done: Deferred[F, Either[Throwable, Unit]]): F[Unit] =
       effect.delay {
         signals.updateAndGet(list => list :+ BlockingOp(blockingOperation, done))
         ()
       }
 
-    /** Suspends until every recorded blocking operation has signalled completion. */
+    /** Suspends until every recorded blocking operation has signalled completion, then re-raises the first failure if
+      * any blocking op failed.
+      */
     def waitForCompletion: F[Unit] =
-      Monad.sequenceDiscard(signals.get().map(_.done.get))
+      Monad.sequence(signals.get().map(_.done.get)).flatMap { outcomes =>
+        outcomes.collectFirst { case Left(error) => error } match
+          case Some(error) => effect.raiseError(error)
+          case None        => effect.pure(())
+      }
 
     /** Drops all bookkeeping; the scheduler clears after waiting. */
     def clear: F[Unit] =
@@ -229,7 +238,7 @@ object Context:
     def completeAll: F[Unit] =
       for
         _ <- Monad.sequenceDiscard(signals.get().map(_.blockingOperation.cancel))
-        _ <- Monad.sequenceDiscard(signals.get().map(_.done.complete(()).void))
+        _ <- Monad.sequenceDiscard(signals.get().map(_.done.complete(Right(())).void))
       yield ()
 
   /** Per-process runtime state held by the [[Context]].

--- a/core/src/main/scala/io/parapet/core/Context.scala
+++ b/core/src/main/scala/io/parapet/core/Context.scala
@@ -189,34 +189,33 @@ object Context:
   )(using effect: Effect[F]): F[Context[F]] =
     effect.delay(new Context[F](config, eventStore, eventTransformers))
 
-  /** Pairs a long-running blocking operation with the [[Deferred]] that records how it completed, used by [[AsyncOps]].
+  /** Pairs an offloaded operation with the [[Deferred]] that records how it completed.
     */
-  final case class BlockingOp[F[_]](
-      blockingOperation: EffectFiber[F, Unit],
-      done: Deferred[F, Either[Throwable, Unit]]
+  final private case class OffloadHandle[F[_]](
+      fiber: EffectFiber[F, Unit],
+      completion: Deferred[F, Either[Throwable, Unit]]
   )
 
-  /** Bookkeeping for blocking operations spawned by a single process.
+  /** Bookkeeping for offloaded operations spawned by a single process.
     *
-    * The scheduler tracks them so it can wait for completion before releasing the process lock - preserving the
-    * per-process "no concurrent handler" guarantee even in the presence of `dsl.blocking` blocks.
+    * The scheduler tracks them so it can wait for completion before releasing the process lock.
     */
-  final class AsyncOps[F[_]](using effect: Effect[F]):
-    private val signals = new AtomicReference[List[BlockingOp[F]]](Nil)
+  final class OffloadTracker[F[_]](using effect: Effect[F]):
+    private val signals = new AtomicReference[List[OffloadHandle[F]]](Nil)
 
-    /** Tracks one in-flight blocking operation. Called by the scheduler when entering a `dsl.blocking` region.
+    /** Add offloaded operation to tracking.
       */
-    def add(blockingOperation: EffectFiber[F, Unit], done: Deferred[F, Either[Throwable, Unit]]): F[Unit] =
+    def add(fiber: EffectFiber[F, Unit], completion: Deferred[F, Either[Throwable, Unit]]): F[Unit] =
       effect.delay {
-        signals.updateAndGet(list => list :+ BlockingOp(blockingOperation, done))
+        signals.updateAndGet(list => list :+ OffloadHandle(fiber, completion))
         ()
       }
 
-    /** Suspends until every recorded blocking operation has signalled completion, then re-raises the first failure if
-      * any blocking op failed.
+    /** Suspends until every recorded offloaded operation has signalled completion, then re-raises the first failure if
+      * any offload op failed.
       */
     def waitForCompletion: F[Unit] =
-      Monad.sequence(signals.get().map(_.done.get)).flatMap { outcomes =>
+      Monad.sequence(signals.get().map(_.completion.get)).flatMap { outcomes =>
         outcomes.collectFirst { case Left(error) => error } match
           case Some(error) => effect.raiseError(error)
           case None        => effect.pure(())
@@ -229,16 +228,16 @@ object Context:
         ()
       }
 
-    /** Number of currently-tracked blocking operations. */
+    /** Number of currently-tracked offloaded operations. */
     def size: F[Int] =
       effect.pure(signals.get().size)
 
-    /** Cancels every tracked operation and completes their deferreds. Used during process stop to unblock callers.
+    /** Cancels every tracked offload operation.
       */
-    def completeAll: F[Unit] =
+    def cancelAll: F[Unit] =
       for
-        _ <- Monad.sequenceDiscard(signals.get().map(_.blockingOperation.cancel))
-        _ <- Monad.sequenceDiscard(signals.get().map(_.done.complete(Right(())).void))
+        _ <- Monad.sequenceDiscard(signals.get().map(_.fiber.cancel))
+        _ <- Monad.sequenceDiscard(signals.get().map(_.completion.complete(Right(())).void))
       yield ()
 
   /** Per-process runtime state held by the [[Context]].
@@ -259,15 +258,15 @@ object Context:
       val terminationSignal: Deferred[F, Unit]
   )(using effect: Effect[F]):
 
-    private val terminatedRef = new AtomicBoolean(false)
-    private val stoppedRef    = new AtomicBoolean(false)
-    private val suspendedRef  = new AtomicBoolean(false)
-    private val blockingRef   = new AsyncOps[F]
-    private val processLock   = new ProcessState.ProcessLock[F]
+    private val terminatedRef  = new AtomicBoolean(false)
+    private val stoppedRef     = new AtomicBoolean(false)
+    private val suspendedRef   = new AtomicBoolean(false)
+    private val offloadTracker = new OffloadTracker[F]
+    private val processLock    = new ProcessState.ProcessLock[F]
 
-    /** Bookkeeping for blocking operations spawned by this process. */
-    def blocking: AsyncOps[F] =
-      blockingRef
+    /** Bookkeeping for offloaded operations spawned by this process. */
+    def offloads: OffloadTracker[F] =
+      offloadTracker
 
     /** Non-blocking enqueue; returns `false` when the mailbox is full. */
     def tryPut(task: Task[F]): F[Boolean] =
@@ -298,9 +297,9 @@ object Context:
     def stopped: F[Boolean] =
       effect.pure(stoppedRef.get())
 
-    /** True if the process has any in-flight blocking operations. */
-    def isBlocking: F[Boolean] =
-      blocking.size.map(_ > 0)
+    /** True if the process has any in-flight offloaded operations. */
+    def hasOffloads: F[Boolean] =
+      offloads.size.map(_ > 0)
 
     /** True if a worker currently holds the per-process lock. */
     def acquired: F[Boolean] =

--- a/core/src/main/scala/io/parapet/core/Dsl.scala
+++ b/core/src/main/scala/io/parapet/core/Dsl.scala
@@ -85,16 +85,14 @@ object Dsl:
   /** Evaluates a pure but lazy `A`. */
   final case class Eval[F[_], G[_], A](thunk: () => A) extends FlowOp[F, A]
 
-  /** Legacy internal name for the user-facing [[FlowOps.offload]] operation.
+  /** Starts `body` on a background effect fiber while keeping the current handler flow running.
     *
     * Semantics:
     *   - `body` is started on a background effect fiber
     *   - the current handler flow continues immediately
     *   - the process does not accept its next mailbox event until all offloaded work completes
-    *
-    * The algebra node keeps the historic name for compatibility; new user code should prefer `offload(...)`.
     */
-  final case class Blocking[F[_], G[_], A](body: () => Free[G, A]) extends FlowOp[F, Unit]
+  final case class Offload[F[_], G[_], A](body: () => Free[G, A]) extends FlowOp[F, Unit]
 
   /** Aborts the program with `error`. */
   final case class RaiseError[F[_], A](error: Throwable) extends FlowOp[F, A]
@@ -473,7 +471,7 @@ object Dsl:
       * mailbox event.
       */
     def offload[A](thunk: => Free[C, A]): Free[C, Unit] =
-      Free.inject[[x] =>> FlowOp[F, x], C, Unit](Blocking[F, C, A](() => thunk))
+      Free.inject[[x] =>> FlowOp[F, x], C, Unit](Offload[F, C, A](() => thunk))
 
     /** Deprecated alias for [[offload]]. The old name suggested inline waiting semantics that are not actually
       * provided.

--- a/core/src/main/scala/io/parapet/core/Dsl.scala
+++ b/core/src/main/scala/io/parapet/core/Dsl.scala
@@ -85,7 +85,15 @@ object Dsl:
   /** Evaluates a pure but lazy `A`. */
   final case class Eval[F[_], G[_], A](thunk: () => A) extends FlowOp[F, A]
 
-  /** Marks `body` as blocking; the runtime offloads it so it does not stall worker threads. */
+  /** Legacy internal name for the user-facing [[FlowOps.offload]] operation.
+    *
+    * Semantics:
+    *   - `body` is started on a background effect fiber
+    *   - the current handler flow continues immediately
+    *   - the process does not accept its next mailbox event until all offloaded work completes
+    *
+    * The algebra node keeps the historic name for compatibility; new user code should prefer `offload(...)`.
+    */
   final case class Blocking[F[_], G[_], A](body: () => Free[G, A]) extends FlowOp[F, Unit]
 
   /** Aborts the program with `error`. */
@@ -441,23 +449,41 @@ object Dsl:
     def eval[A](thunk: => A): Free[C, A] =
       Free.inject[[x] =>> FlowOp[F, x], C, A](Eval[F, C, A](() => thunk))
 
-    /** Marks `thunk` as blocking; the runtime offloads it so it does not stall scheduler worker threads.
+    /** Starts `thunk` on a background effect fiber so it does not stall scheduler worker threads.
       *
       * Example:
       *
       * {{{
       * class BlockingProcess extends Process[F]:
       *   override def handle: Receive =
-      *     case Start => blocking(eval(while true do {})) ++ eval(println("now"))
+      *     case Start => offload(eval(while true do {})) ++ eval(println("now"))
       * }}}
       *
-      * Output: `now`. The infinite loop runs on a separate worker, so the process is free to handle subsequent events.
+      * Output: `now`. The infinite loop runs on a separate worker, so the current handler flow can continue
+      * immediately.
       *
-      * Note: `blocking` differs from [[fork]] - a forked program is fire-and-forget and the parent process keeps
-      * consuming new events while it runs; with `blocking` the process is suspended until the body completes.
+      * Important: `offload(thunk) ++ next` does **not** wait for `thunk` to finish before `next` runs. The barrier is
+      * at the process boundary, not at the current DSL step:
+      *
+      *   - later steps in the same handler flow may run immediately
+      *   - the process will not accept its next mailbox event until all offloaded work completes
+      *
+      * This differs from [[fork]] in one important way: a forked program is fully fire-and-forget, so the parent
+      * process keeps consuming new mailbox events while it runs. `offload` still gates the process before the next
+      * mailbox event.
       */
-    def blocking[A](thunk: => Free[C, A]): Free[C, Unit] =
+    def offload[A](thunk: => Free[C, A]): Free[C, Unit] =
       Free.inject[[x] =>> FlowOp[F, x], C, Unit](Blocking[F, C, A](() => thunk))
+
+    /** Deprecated alias for [[offload]]. The old name suggested inline waiting semantics that are not actually
+      * provided.
+      */
+    @deprecated(
+      "Use offload(...) instead. blocking(...) starts work in the background and only gates the next mailbox event; it does not wait inline before the next ++ step.",
+      since = "2026-05"
+    )
+    def blocking[A](thunk: => Free[C, A]): Free[C, Unit] =
+      offload(thunk)
 
     /** Aborts the program with `error`. Subsequent steps are skipped unless the error is caught by [[handleError]].
       */
@@ -500,15 +526,6 @@ object Dsl:
     def halt(ref: ProcessRef): Free[C, Unit] =
       Free.inject[[x] =>> FlowOp[F, x], C, Unit](Halt[F](ref))
 
-    /** Acquires the per-process lock for `ref`. Cooperative - only meaningful between programs that opt into it.
-      */
-    def lock(ref: ProcessRef): Free[C, Unit] =
-      Free.inject[[x] =>> FlowOp[F, x], C, Unit](Lock[F](ref))
-
-    /** Releases the per-process lock for `ref`. */
-    def unlock(ref: ProcessRef): Free[C, Unit] =
-      Free.inject[[x] =>> FlowOp[F, x], C, Unit](Unlock[F](ref))
-
     private def sequence[A](values: List[Free[C, A]]): Free[C, List[A]] =
       values.foldRight(pure(List.empty[A])) { (current, acc) =>
         current.flatMap(value => acc.map(value :: _))
@@ -524,6 +541,34 @@ object Dsl:
       */
     given [F[_], G[_]](using Inject[[x] =>> FlowOp[F, x], G]): FlowOps[F, G] =
       new FlowOps[F, G]
+
+  /** Runtime-only helpers that manipulate scheduler/process machinery rather than expressing normal application
+    * behavior.
+    *
+    * Unlike [[FlowOps]], this is not exposed through the default `dsl` member on [[Process]]. Callers must opt in
+    * explicitly, which keeps process-lock operations out of the normal user-facing DSL surface.
+    */
+  private[core] class RuntimeOps[F[_], C[_]](using inject: Inject[[x] =>> FlowOp[F, x], C]):
+
+    /** Acquires the runtime per-process delivery lock for `ref`.
+      *
+      * This is not a general-purpose application mutex. It is intended for runtime helpers that need to coordinate
+      * directly with the scheduler's process-serialization machinery.
+      */
+    def lockProcess(ref: ProcessRef): Free[C, Unit] =
+      Free.inject[[x] =>> FlowOp[F, x], C, Unit](Lock[F](ref))
+
+    /** Releases the runtime per-process delivery lock for `ref`, and re-notifies the scheduler to resume draining that
+      * process mailbox.
+      */
+    def unlockProcess(ref: ProcessRef): Free[C, Unit] =
+      Free.inject[[x] =>> FlowOp[F, x], C, Unit](Unlock[F](ref))
+
+  private[core] object RuntimeOps:
+    type Aux[F[_]] = RuntimeOps[F, [x] =>> Dsl[F, x]]
+
+    given [F[_], G[_]](using Inject[[x] =>> FlowOp[F, x], G]): RuntimeOps[F, G] =
+      new RuntimeOps[F, G]
 
   /** Mixin granting access to the `dsl` member - a [[FlowOps]] instance over the parapet algebra. Mixed into
     * [[Process]] so that handlers can write `dsl.send(...)`, `dsl.eval(...)`, etc.

--- a/core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -120,7 +120,7 @@ object DslInterpreter:
               val second0 = second.asInstanceOf[DslF[F, Any]].foldMap(interpret(sender, processState, execTrace))
               effect.race(first0, second0).asInstanceOf[F[A]]
 
-            case Blocking(body) =>
+            case Offload(body) =>
               for
                 done  <- Deferred[F, Either[Throwable, Unit]]()
                 fiber <- effect.start(

--- a/core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -124,12 +124,14 @@ object DslInterpreter:
 
             case Blocking(body) =>
               for
-                done  <- Deferred[F, Unit]()
+                done  <- Deferred[F, Either[Throwable, Unit]]()
                 fiber <- effect.start(
                   body()
                     .asInstanceOf[DslF[F, Any]]
                     .foldMap(interpret(sender, processState, execTrace))
-                    .flatMap(_ => done.complete(()).void)
+                    .map(_ => Right(()))
+                    .handleErrorWith(error => effect.pure(Left(error)))
+                    .flatMap(outcome => done.complete(outcome).void)
                 )
                 _ <- processState.blocking.add(fiber, done)
               yield ().asInstanceOf[A]

--- a/core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -58,19 +58,19 @@ object DslInterpreter:
         def apply[A](fa: FlowOp[F, A]): F[A] =
           fa match
             case Dsl.Pure(value) =>
-              effect.pure(value).asInstanceOf[F[A]]
+              effect.pure(value)
 
             case UnitFlow() =>
-              effect.pure(()).asInstanceOf[F[A]]
+              effect.pure(())
 
             case Send(event, senderOverride, receiver, receivers) =>
               val source = senderOverride.getOrElse(processState.process.ref)
               val first  = send(source, event, receiver, execTrace)
               if receivers.nonEmpty then
-                (first >> receivers.foldLeft(effect.pure(())) { (acc, next) =>
+                first >> receivers.foldLeft(effect.pure(())) { (acc, next) =>
                   acc >> send(source, event, next, execTrace)
-                }).asInstanceOf[F[A]]
-              else first.asInstanceOf[F[A]]
+                }
+              else first
 
             case WithSender(runWithSender) =>
               runWithSender
@@ -83,13 +83,11 @@ object DslInterpreter:
                 .foldLeft(effect.pure(())) { (acc, receiver) =>
                   acc >> send(sender, event, receiver, execTrace)
                 }
-                .asInstanceOf[F[A]]
 
             case Par(flow) =>
               flow
                 .asInstanceOf[DslF[F, Unit]]
                 .foldMap(interpret(sender, processState, execTrace))
-                .asInstanceOf[F[A]]
 
             case Fork(flow) =>
               effect
@@ -101,13 +99,13 @@ object DslInterpreter:
                 .map(fiber => Fiber.RuntimeFiber(fiber).asInstanceOf[A])
 
             case delay: Delay[F] =>
-              effect.sleep(delay.duration).asInstanceOf[F[A]]
+              effect.sleep(delay.duration)
 
             case Eval(thunk) =>
-              effect.delay(thunk().asInstanceOf[A])
+              effect.delay(thunk())
 
             case Suspend(thunk) =>
-              effect.suspend(thunk().asInstanceOf[F[A]])
+              effect.suspend(thunk())
 
             case SuspendF(thunk) =>
               effect
@@ -137,7 +135,7 @@ object DslInterpreter:
               yield ().asInstanceOf[A]
 
             case Register(parent, process: Process[F] @unchecked) =>
-              context.registerAndStart(parent, process).void.asInstanceOf[F[A]]
+              context.registerAndStart(parent, process).void
 
             case RaiseError(error) =>
               effect.raiseError(error)
@@ -149,7 +147,7 @@ object DslInterpreter:
               }
 
             case Halt(ref) =>
-              context.remove(ref).void.asInstanceOf[F[A]]
+              context.remove(ref).void
 
             case Guarantee(body, finalizer) =>
               effect
@@ -157,18 +155,17 @@ object DslInterpreter:
                   finalizer().asInstanceOf[DslF[F, Unit]].foldMap(interpret(sender, processState, execTrace))
                 }
                 .void
-                .asInstanceOf[F[A]]
 
             case Dsl.Lock(ref) =>
-              context.getProcessState(ref).get.acquire.void.asInstanceOf[F[A]]
+              context.getProcessState(ref).get.acquire.void
 
             case Dsl.Unlock(ref) =>
-              (context.getProcessState(ref).get.release >>
+              context.getProcessState(ref).get.release >>
                 context
                   .schedule(
                     Scheduler.Deliver(Envelope(ProcessRef.SystemRef, Scheduler.Inbox, ref), execTrace)
                   )
-                  .void).asInstanceOf[F[A]]
+                  .void
 
     private def send(
         sender: ProcessRef,

--- a/core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -133,7 +133,7 @@ object DslInterpreter:
                     .handleErrorWith(error => effect.pure(Left(error)))
                     .flatMap(outcome => done.complete(outcome).void)
                 )
-                _ <- processState.blocking.add(fiber, done)
+                _ <- processState.offloads.add(fiber, done)
               yield ().asInstanceOf[A]
 
             case Register(parent, process: Process[F] @unchecked) =>

--- a/core/src/main/scala/io/parapet/core/Scheduler.scala
+++ b/core/src/main/scala/io/parapet/core/Scheduler.scala
@@ -417,7 +417,7 @@ object Scheduler:
               case Some(task: Deliver[F]) =>
                 if task.envelope.event.isInstanceOf[Scheduler.Inbox.type] then step(remaining)
                 else
-                  deliver(processState, task) >> processState.isBlocking.flatMap {
+                  deliver(processState, task) >> processState.hasOffloads.flatMap {
                     case true  => waitForCompletion(task, processState)
                     case false => step(remaining - 1)
                   }
@@ -515,14 +515,14 @@ object Scheduler:
 
       private def waitForCompletion(deliver: Deliver[F], processState: ProcessState[F]): F[Unit] =
         for
-          numberOfBlockingOps <- processState.blocking.size
-          _                   <- logger.debug(
-            s"worker[$name]::waits for completion of $numberOfBlockingOps blocking operations. process: ${processState.process.ref}"
+          offloadCount <- processState.offloads.size
+          _            <- logger.debug(
+            s"worker[$name]::waits for completion of $offloadCount offloaded operations. process: ${processState.process.ref}"
           )
           _ <- effect.start(
             effect.guarantee(
               runEffect(
-                processState.blocking.waitForCompletion,
+                processState.offloads.waitForCompletion,
                 deliver.envelope,
                 processState,
                 error =>
@@ -538,8 +538,8 @@ object Scheduler:
               )
             ) {
               logger.debug(
-                s"worker[$name]:: $numberOfBlockingOps blocking operations completed. process: ${processState.process.ref}"
-              ) >> processState.blocking.clear >> releaseAndNotify(processState)
+                s"worker[$name]:: $offloadCount offloaded operations completed. process: ${processState.process.ref}"
+              ) >> processState.offloads.clear >> releaseAndNotify(processState)
             }
           )
         yield ()
@@ -665,7 +665,7 @@ object Scheduler:
             processState.stop().flatMap {
               case true =>
                 stopChildProcesses >>
-                  processState.blocking.completeAll >>
+                  processState.offloads.cancelAll >>
                   deliverStopEvent(sender, processState, interpreter, execTrace)
                     .handleErrorWith(error => onError(receiver, error)) >>
                   logger.debug(s"process: '$receiver' has been stopped") >>

--- a/core/src/test/scala/io/parapet/core/TestUtils.scala
+++ b/core/src/test/scala/io/parapet/core/TestUtils.scala
@@ -74,7 +74,7 @@ object TestUtils:
         case Eval(thunk) =>
           thunk().asInstanceOf[A]
 
-        case Blocking(body) =>
+        case Offload(body) =>
           body().asInstanceOf[DslF[Id, Any]].foldMap(this)
           ().asInstanceOf[A]
 

--- a/intg-tests/src/main/scala/io/parapet/tests/intg/BlockingSpec.scala
+++ b/intg-tests/src/main/scala/io/parapet/tests/intg/BlockingSpec.scala
@@ -1,11 +1,12 @@
 package io.parapet.tests.intg
 
-import io.parapet.core.Events.{Kill, Start, Stop}
+import io.parapet.core.Events.{Failure, Kill, Start, Stop}
 import io.parapet.core.Parapet.ParConfig
 import io.parapet.core.Process
 import io.parapet.core.Scheduler.SchedulerConfig
+import io.parapet.core.exceptions.EventHandlingException
 import io.parapet.testutils.EventStore
-import io.parapet.{Event, ProcessRef}
+import io.parapet.{Envelope, Event, ProcessRef}
 import org.scalatest.OptionValues._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._
@@ -28,7 +29,7 @@ abstract class BlockingSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
 
     val slowProcess = Process
       .builder[F](_ => { case Start =>
-        TestEvent ~> fastRef ++ blocking(eval(while (true) {})) ++ TestEvent ~> fastRef
+        TestEvent ~> fastRef ++ offload(eval(while (true) {})) ++ TestEvent ~> fastRef
       })
       .ref(slowRef)
       .name("slow")
@@ -62,7 +63,7 @@ abstract class BlockingSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
     val process = Process(ref => {
       case Start =>
         (0 until total)
-          .map(_ => blocking(delay((1 + Random.nextInt(3)).seconds) ++ eval(count.incrementAndGet())))
+          .map(_ => offload(delay((1 + Random.nextInt(3)).seconds) ++ eval(count.incrementAndGet())))
           .reduce(_ ++ _) ++ Done ~> ref
 
       case Done => eval(eventStore.add(ref, NumEvent(count.get())))
@@ -78,7 +79,7 @@ abstract class BlockingSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
 
     val process = Process(ref => {
       case Start =>
-        blocking {
+        offload {
           eval(println("start blocking")) ++
             delay(1.minute)
         }
@@ -87,6 +88,47 @@ abstract class BlockingSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
 
     unsafeRun(eventStore.await(1, createApp(ct.pure(Seq(onStart(Kill ~> process), process))).run))
     eventStore.get(process.ref) shouldBe Seq(Stop)
+  }
+
+  test("blocking failure is reported and does not wedge the process") {
+    val eventStore = new EventStore[F, Event]
+
+    case object ServerError extends RuntimeException("error")
+
+    val serverRef = ProcessRef("blocking-server")
+    val clientRef = ProcessRef("blocking-client")
+
+    val server = Process
+      .builder[F](ref => {
+        case Trigger =>
+          offload(raiseError(ServerError))
+        case Ping =>
+          eval(eventStore.add(ref, Ping))
+      })
+      .ref(serverRef)
+      .build
+
+    val client = Process
+      .builder[F](ref => {
+        case Start =>
+          Trigger ~> serverRef ++
+            delay(50.millis) ++
+            Ping ~> serverRef
+        case failure: Failure =>
+          eval(eventStore.add(ref, failure))
+      })
+      .ref(clientRef)
+      .build
+
+    unsafeRun(eventStore.await(2, createApp(ct.pure(Seq(client, server))).run))
+
+    eventStore.get(server.ref) shouldBe Seq(Ping)
+    eventStore.get(client.ref).headOption.value should matchPattern {
+      case Failure(
+            Envelope(client.`ref`, Trigger, server.`ref`),
+            EventHandlingException(_, ServerError)
+          ) =>
+    }
   }
 
 }
@@ -98,5 +140,9 @@ object BlockingSpec {
   object Done extends Event
 
   case class NumEvent(i: Int) extends Event
+
+  object Trigger extends Event
+
+  object Ping extends Event
 
 }

--- a/intg-tests/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
+++ b/intg-tests/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
@@ -53,7 +53,7 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
       override def handle: Receive = {
         case Start =>
           register(ref, ch) ++
-            blocking {
+            offload {
               (0 until numOfRequests).map(i => sendRequest(Request(i))).reduce(_ ++ _)
             }
         case Stop => unit

--- a/intg-tests/src/main/scala/io/parapet/tests/intg/scheduler/TestProcesses.scala
+++ b/intg-tests/src/main/scala/io/parapet/tests/intg/scheduler/TestProcesses.scala
@@ -21,7 +21,7 @@ object TestProcesses {
     * @param time
     *   handler delay. [[TaskProcessingTime.instant]] means zero delay.
     * @param blockingHandler
-    *   when true, wraps the body in `blocking { ... }`.
+    *   when true, wraps the body in `offload { ... }`.
     */
   def create[F[_]](
       eventStore: EventStore[F, TestEvent],
@@ -32,7 +32,7 @@ object TestProcesses {
       import dsl._
       val handle: Receive = { case e: TestEvent =>
         val body = delay(time) ++ eval(eventStore.add(ref, e))
-        if (blockingHandler) blocking(body) else body
+        if (blockingHandler) offload(body) else body
       }
     }
 
@@ -45,7 +45,7 @@ object TestProcesses {
     * @param eventStore
     *   sink shared by all processes.
     * @param blockingRatio
-    *   fraction of processes using `blocking { ... }`.
+    *   fraction of processes using `offload { ... }`.
     */
   def createAll[F[_]](
       n: Int,
@@ -61,7 +61,7 @@ object TestProcesses {
     processes
   }
 
-  /** Picks the indexes in `[0, n)` that should use `blocking { ... }`, spread on a uniform stride.
+  /** Picks the indexes in `[0, n)` that should use `offload { ... }`, spread on a uniform stride.
     *
     * Algorithm:
     *   - `bN = round(n * blockingRatio)`, clamped to `[0, n]` - how many processes should block.

--- a/net/src/main/scala/io/parapet/net/processes/TcpClientProcess.scala
+++ b/net/src/main/scala/io/parapet/net/processes/TcpClientProcess.scala
@@ -28,7 +28,7 @@ class TcpClientProcess[F[_]](
 
   override def handle: Receive = {
     case Cmd.netClient.Send(data, replyTo) =>
-      blocking {
+      offload {
         suspend(client.request(data)).flatMap {
           case Some(response) =>
             replyTo match

--- a/net/src/main/scala/io/parapet/net/processes/TcpServerProcess.scala
+++ b/net/src/main/scala/io/parapet/net/processes/TcpServerProcess.scala
@@ -30,7 +30,7 @@ class TcpServerProcess[F[_]](
   override val name: String = "tcp-server"
 
   private def receiveLoop: Program = flow {
-    blocking {
+    offload {
       suspend(server.receive).flatMap {
         case Some(frame) => Cmd.netServer.Message(frame.clientId, frame.payload) ~> sink
         case None        => unit
@@ -43,7 +43,7 @@ class TcpServerProcess[F[_]](
       fork(receiveLoop).void
 
     case Cmd.netServer.Send(clientId, data) =>
-      blocking {
+      offload {
         suspend(server.reply(clientId, data))
       }
 

--- a/net/src/main/scala/io/parapet/net/processes/UdpBroadcastProcess.scala
+++ b/net/src/main/scala/io/parapet/net/processes/UdpBroadcastProcess.scala
@@ -36,7 +36,7 @@ class UdpBroadcastProcess[F[_]](
   override val name: String = "udp-broadcast"
 
   private def receiveLoop: Program = flow {
-    blocking {
+    offload {
       suspend(transport.receiveBatch(pollLimit)).flatMap { payloads =>
         payloads.foldLeft(unit) { (acc, payload) =>
           acc ++ UdpEvents.Message(payload) ~> sink
@@ -50,7 +50,7 @@ class UdpBroadcastProcess[F[_]](
       fork(receiveLoop).void
 
     case UdpEvents.Send(payload) =>
-      blocking {
+      offload {
         suspend(transport.publish(payload))
       }
 


### PR DESCRIPTION
This PR main changes:

1. fixes the runtime so failed offloaded/blocking work no longer wedges a process forever
2. introduces offload(...) as the preferred DSL API and deprecates blocking(...)
3. moves process-lock helpers out of the normal public DSL.

blocking was misleading b/c it does not wait blocking body to complete before moving the next ++ step.
another main problem: failures in background blocking work could leave a process permanently stuck.

fixes:

- AsyncOps now tracks completion as Either[Throwable, Unit] instead of just Unit
- waitForCompletion re-raises the first blocking failure back into the scheduler
- this preserves liveness and lets the normal Failure(...) path notify the sender