### PR TITLE
adding Out protocol to process

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ typed DSL, executed by the runtime against any compatible effect type.
 final case class Ping(n: Int) extends Event
 final case class Pong(n: Int) extends Event
 
-class Echo[F[_]](peer: ProcessRef[Ping]) extends Process[F, Ping | Pong]:
+class Echo[F[_]](peer: ProcessRef[Ping]) extends Process[F, Ping | Pong, Pong]:
   import dsl.*
   override def handle: Receive =
     case Start              => Ping(0) ~> peer              // kick things off
@@ -117,7 +117,7 @@ application boundary. A process declares its API as events and reacts to them in
 import io.parapet.{Event, ProcessRef}
 import io.parapet.core.Process
 
-class Printer[F[_]] extends Process[F, Printer.Print]:
+class Printer[F[_]] extends Process[F, Printer.Print, Nothing]:
   import Printer.*
   import dsl.*
 
@@ -135,7 +135,7 @@ import io.parapet.ProcessRef
 import io.parapet.core.Process
 import io.parapet.core.Events.Start
 
-class Greeter[F[_]](printer: ProcessRef[Printer.Print]) extends Process[F, Event]:
+class Greeter[F[_]](printer: ProcessRef[Printer.Print]) extends Process[F, Event, Nothing]:
   import dsl.*
   override def handle: Receive =
     case Start => Printer.Print("hello world") ~> printer
@@ -150,18 +150,18 @@ Notes:
 
 ## Typed process refs
 
-Declare a process protocol with `Process[F, MyEvent]`, then pass around `ProcessRef[MyEvent]` to keep wiring explicit.
+Declare a process protocol with `Process[F, In, Out]`, then pass around `ProcessRef[In]` to keep wiring explicit.
 
 ```scala
 final case class Save(key: String, value: String) extends Event
 
-class Store[F[_]] extends Process[F, Save]:
+class Store[F[_]] extends Process[F, Save, Nothing]:
   import dsl.*
   override def handle: Receive =
     case Save(key, value) => eval(println(s"saved $key=$value"))
     case Stop             => eval(println("closing store"))
 
-class Writer[F[_]](store: ProcessRef[Save]) extends Process[F, Event]:
+class Writer[F[_]](store: ProcessRef[Save]) extends Process[F, Event, Nothing]:
   import dsl.*
   override def handle: Receive =
     case Start => Save("hello", "world") ~> store
@@ -178,7 +178,7 @@ import io.parapet.cats.CatsEffectParApp
 import io.parapet.core.Process
 
 object HelloApp extends CatsEffectParApp:
-  def processes(args: Array[String]): IO[Seq[Process[IO, ?]]] =
+  def processes(args: Array[String]): IO[Seq[Process[IO, ?, ?]]] =
     IO.delay {
       val printer = new Printer[IO]
       val greeter = new Greeter[IO](printer.ref)
@@ -212,7 +212,6 @@ The full set of combinators:
 | `event ~> ref`             | Send `event` to a process.                               |
 | `forward(event, ref)`      | Send while preserving the original sender.               |
 | `reply(event)`             | Send `event` back to the sender of the current message.  |
-| `withSender(s => program)` | Run a program parameterised by the current sender ref.   |
 | `flow { ... }`             | Suspend program construction (use for recursion).        |
 | `eval { sideEffect }`      | Suspend a side-effecting computation in `F`.             |
 | `evalWith(value)(f)`       | Evaluate `value` and feed it into a program builder.     |
@@ -240,11 +239,11 @@ import io.parapet.effect.Effect
 final case class Request(data: String) extends Event
 final case class Response(data: String) extends Event
 
-def server[F[_]]: Process[F, Request] = Process.typed[F, Request](_ => {
-  case Request(data) => reply(Response(s"echo: $data"))
-})
+class Server[F[_]] extends Process[F, Request, Response]:
+  override def handle: Receive =
+    case Request(data) => reply(Response(s"echo: $data"))
 
-class Client[F[_]: Effect](backend: ProcessRef[Request]) extends Process[F, Event]:
+class Client[F[_]: Effect](backend: ProcessRef[Request]) extends Process[F, Event, Nothing]:
   import dsl.*
   private lazy val ch = Channel[F]()
 

--- a/parapet-cats-effect/src/test/scala/io/parapet/tests/intg/cats/CatsEffectSpecs.scala
+++ b/parapet-cats-effect/src/test/scala/io/parapet/tests/intg/cats/CatsEffectSpecs.scala
@@ -9,20 +9,20 @@ import io.parapet.{ParApp, core}
 
 trait BasicCatsEffectSpec extends IntegrationSpec[IO] with CatsEffectParApp:
   override def createApp(
-      processes0: IO[Seq[core.Process[IO, ?]]],
+      processes0: IO[Seq[core.Process[IO, ?, ?]]],
       deadLetter0: Option[IO[DeadLetterProcess[IO]]],
       config0: Parapet.ParConfig
   ): ParApp[IO] =
     new CatsEffectParApp:
       override val config: Parapet.ParConfig = config0
 
-      override def processes(args: Array[String]): IO[Seq[core.Process[IO, ?]]] =
+      override def processes(args: Array[String]): IO[Seq[core.Process[IO, ?, ?]]] =
         processes0
 
       override def deadLetter: IO[DeadLetterProcess[IO]] =
         deadLetter0.getOrElse(super.deadLetter)
 
-  override def processes(args: Array[String]): IO[Seq[core.Process[IO, ?]]] =
+  override def processes(args: Array[String]): IO[Seq[core.Process[IO, ?, ?]]] =
     IO.pure(Seq.empty)
 
 class BlockingSpec extends io.parapet.tests.intg.BlockingSpec[IO] with BasicCatsEffectSpec

--- a/parapet-core/src/main/scala/io/parapet/ParApp.scala
+++ b/parapet-core/src/main/scala/io/parapet/ParApp.scala
@@ -83,7 +83,7 @@ trait ParApp[F[_]] extends FlowSyntax[F]:
     * @param args
     *   command-line arguments passed to [[main]] / [[run]].
     */
-  def processes(args: Array[String]): F[Seq[Process[F, ?]]]
+  def processes(args: Array[String]): F[Seq[Process[F, ?, ?]]]
 
   /** Returns the [[DeadLetterProcess]] used for events that could not be delivered. By default a logging implementation
     * is installed; override to plug in custom behavior (metrics, alerting, persistence).

--- a/parapet-core/src/main/scala/io/parapet/core/Channel.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Channel.scala
@@ -22,7 +22,7 @@ import scala.util.Try
   *   optional fixed reference; defaults to a fresh UUID.
   */
 class Channel[F[_]](override val ref: ProcessRef[Event] = ProcessRef.jdkUUIDRef[Event])(using Effect[F])
-    extends Process[F, Event]:
+    extends Process[F, Event, Event]:
   import Channel.*
   import dsl.*
 

--- a/parapet-core/src/main/scala/io/parapet/core/Cond.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Cond.scala
@@ -22,7 +22,8 @@ import scala.util.Try
   * @param timeout
   *   maximum time to wait for a satisfying event before responding with `Result(None)`.
   */
-class Cond[F[_]](predicate: Event => Boolean, timeout: FiniteDuration)(using Effect[F]) extends Process[F, Event]:
+class Cond[F[_]](predicate: Event => Boolean, timeout: FiniteDuration)(using Effect[F])
+    extends Process[F, Event, Event]:
   import dsl.*
 
   private val done                       = new AtomicBoolean()

--- a/parapet-core/src/main/scala/io/parapet/core/Context.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Context.scala
@@ -82,7 +82,7 @@ class Context[F[_]](
     * @throws io.parapet.core.exceptions.UnknownProcessException
     *   if `parent` is not registered.
     */
-  def register(parent: ProcessRef.Unknown, child: Process[F, ?]): F[ProcessRef.Unknown] =
+  def register(parent: ProcessRef.Unknown, child: Process[F, ?, ?]): F[ProcessRef.Unknown] =
     effect.suspend {
       if !processes.containsKey(parent) then
         effect.raiseError(UnknownProcessException(s"process cannot be registered because parent $parent doesn't exist"))
@@ -110,7 +110,7 @@ class Context[F[_]](
     graph.getOrDefault(parent, ListBuffer.empty).toVector
 
   /** Combination of [[register]] and dispatch of the initial [[Events.Start]] event. */
-  def registerAndStart(parent: ProcessRef.Unknown, process: Process[F, ?]): F[SubmissionResult] =
+  def registerAndStart(parent: ProcessRef.Unknown, process: Process[F, ?, ?]): F[SubmissionResult] =
     register(parent, process) >> sendStartEvent(process.ref)
 
   private def sendStartEvent(processRef: ProcessRef.Unknown): F[SubmissionResult] =
@@ -119,22 +119,22 @@ class Context[F[_]](
 
   /** Registers a batch of root processes (parented to [[ProcessRef.SystemRef]]) and starts each.
     */
-  def registerAll(processes0: List[Process[F, ?]]): F[List[ProcessRef.Unknown]] =
+  def registerAll(processes0: List[Process[F, ?, ?]]): F[List[ProcessRef.Unknown]] =
     registerAll(ProcessRef.SystemRef, processes0)
 
   /** Registers and starts each of `processes0` under `parent`. */
-  def registerAll(parent: ProcessRef.Unknown, processes0: List[Process[F, ?]]): F[List[ProcessRef.Unknown]] =
+  def registerAll(parent: ProcessRef.Unknown, processes0: List[Process[F, ?, ?]]): F[List[ProcessRef.Unknown]] =
     for
       refs   <- Monad.sequence(processes0.map(register(parent, _)))
       result <- Monad.sequence(refs.map(ref => sendStartEvent(ref).as(ref)))
     yield result
 
   /** Snapshot of every [[Process]] currently registered (system + user). */
-  def getProcesses: List[Process[F, ?]] =
+  def getProcesses: List[Process[F, ?, ?]] =
     processes.values().asScala.map(_.process).toList
 
   /** Looks up a process by ref. */
-  def getProcess(ref: ProcessRef.Unknown): Option[Process[F, ?]] =
+  def getProcess(ref: ProcessRef.Unknown): Option[Process[F, ?, ?]] =
     getProcessState(ref).map(_.process)
 
   /** Looks up the runtime state (mailbox + lifecycle flags) of a process. */
@@ -254,7 +254,7 @@ object Context:
     */
   final class ProcessState[F[_]](
       queue: TaskQueue[F],
-      val process: Process[F, ?],
+      val process: Process[F, ?, ?],
       val terminationSignal: Deferred[F, Unit]
   )(using effect: Effect[F]):
 
@@ -372,7 +372,7 @@ object Context:
     /** Builds a fresh [[ProcessState]], honoring the process's overridden mailbox size or falling back to the global
       * default.
       */
-    def apply[F[_]](process: Process[F, ?], config: Parapet.ParConfig)(using effect: Effect[F]): F[ProcessState[F]] =
+    def apply[F[_]](process: Process[F, ?, ?], config: Parapet.ParConfig)(using effect: Effect[F]): F[ProcessState[F]] =
       val processBufferSize =
         if process.bufferSize != -1 then process.bufferSize else config.processBufferSize
 

--- a/parapet-core/src/main/scala/io/parapet/core/Dsl.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Dsl.scala
@@ -71,7 +71,7 @@ object Dsl:
 
   /** Registers `child` as a sub-process of `parent`, integrating it into the supervision graph.
     */
-  final case class Register[F[_]](parent: ProcessRef.Unknown, child: Process[F, ?]) extends FlowOp[F, Unit]
+  final case class Register[F[_]](parent: ProcessRef.Unknown, child: Process[F, ?, ?]) extends FlowOp[F, Unit]
 
   /** Races `first` against `second` and returns whichever wins, cancelling the loser. */
   final case class Race[F[_], G[_], A, B](first: Free[G, A], second: Free[G, B]) extends FlowOp[F, Either[A, B]]
@@ -235,23 +235,7 @@ object Dsl:
     /** Forwards `event` to `receiver` (and `other`) while preserving the sender of the event currently being handled -
       * the typical building block of a proxy process.
       *
-      * Example:
-      *
-      * {{{
-      * val server = Process[F](_ => {
-      *   case Request(body) => withSender(sender => eval(println(s"$sender-$body")))
-      * })
-      *
-      * val proxy = Process[F](_ => {
-      *   case Request(body) => forward(Request(s"proxy-$body"), server.ref)
-      * })
-      *
-      * val client = Process.builder[F](_ =>
-      *   { case Start => Request("ping") ~> proxy }
-      * ).ref(ProcessRef("client")).build
-      * }}}
-      *
-      * Console output: `client-proxy-ping`
+      * Use this for proxy-style processes that should preserve the original sender for a downstream [[Process.reply]].
       */
     def forward[E <: Event](
         event: => E,
@@ -301,56 +285,28 @@ object Dsl:
     def delay(duration: FiniteDuration): Free[C, Unit] =
       Free.inject[[x] =>> FlowOp[F, x], C, Unit](Delay[F](duration))
 
-    /** Runs `f` with the current sender's [[ProcessRef]] in scope. The most idiomatic way to inspect or reuse the
-      * originator of the event being handled.
+    /** Runs `f` with the current sender's [[ProcessRef]] in scope.
       *
-      * For the common "send one event back to the sender" case prefer the [[reply]] sugar below.
-      *
-      * Example:
-      *
-      * {{{
-      * val server = Process[F](_ => {
-      *   case Request(data) => withSender(sender => eval(println(s"$sender says $data")))
-      * })
-      *
-      * val client = Process.builder[F](_ =>
-      *   { case Start => Request("hello") ~> server }
-      * ).ref(ProcessRef("client")).build
-      * }}}
-      *
-      * Console output: `client says hello`
+      * This is intentionally core-private because it exposes the raw, untyped sender ref. User code should use
+      * [[Process.reply]], which checks replies against the process's declared `Out` protocol.
       */
-    def withSender[A](f: ProcessRef[Event] => Free[C, A]): Free[C, A] =
+    @developerApi
+    private[core] def withSender[A](f: ProcessRef[Event] => Free[C, A]): Free[C, A] =
       Free.inject[[x] =>> FlowOp[F, x], C, A](WithSender[F, C, A](f))
 
-    /** Sends `event` back to the sender of the message currently being handled. Sugar for `withSender(event ~> _)`.
+    /** Low-level untyped reply helper for core internals.
       *
-      * Example:
-      *
-      * {{{
-      * val echo = Process[F](_ => {
-      *   case Request(data) => reply(Response(s"echo: $data"))
-      * })
-      * }}}
-      *
-      * If the event being handled has no real sender (e.g. a lifecycle event delivered by
-      * [[io.parapet.core.processes.SystemProcess]]) the reply lands at the system / dead-letter ref - same semantics as
-      * a manual `withSender` reply.
+      * User processes should call [[Process.reply]], which checks the event against the process's declared `Out`
+      * protocol. This helper stays untyped because the generic DSL does not know which process is currently building a
+      * program.
       */
-    def reply(event: => Event): Free[C, Unit] =
+    @developerApi
+    private[core] def reply(event: => Event): Free[C, Unit] =
       withSender(sender => send(event, sender))
 
-    /** Sends each of `events` back to the sender, in order. Useful when a handler emits a small batch of replies.
-      *
-      * Example:
-      *
-      * {{{
-      * val acker = Process[F](_ => {
-      *   case Batch(items) => reply(items.map(Ack(_)))
-      * })
-      * }}}
-      */
-    def reply(events: Seq[Event]): Free[C, Unit] =
+    /** Low-level untyped batch reply helper for core internals. */
+    @developerApi
+    private[core] def reply(events: Seq[Event]): Free[C, Unit] =
       withSender { sender =>
         events.toList match
           case Nil          => unit
@@ -410,7 +366,7 @@ object Dsl:
       * stop server
       * }}}
       */
-    def register(parent: ProcessRef.Unknown, child: Process[F, ?]*): Free[C, Unit] =
+    def register(parent: ProcessRef.Unknown, child: Process[F, ?, ?]*): Free[C, Unit] =
       child
         .map(process => Free.inject[[x] =>> FlowOp[F, x], C, Unit](Register(parent, process)))
         .foldLeft(unit) { (result, next) =>

--- a/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -142,7 +142,7 @@ object DslInterpreter:
                 _ <- processState.offloads.add(fiber, done)
               yield ().asInstanceOf[A]
 
-            case Register(parent, process: Process[F, ?] @unchecked) =>
+            case Register(parent, process: Process[F, ?, ?] @unchecked) =>
               context.registerAndStart(parent, process).void
 
             case RaiseError(error) =>

--- a/parapet-core/src/main/scala/io/parapet/core/Process.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Process.scala
@@ -27,8 +27,13 @@ import java.util.concurrent.atomic.AtomicReference
   *
   * @tparam F
   *   the effect type used by the surrounding runtime.
+  * @tparam In
+  *   the domain events this process accepts.
+  * @tparam Out
+  *   the events this process may emit with [[reply]]. This is a local reply contract; the underlying sender ref is
+  *   still runtime envelope data.
   */
-trait Process[F[_], In <: Event] extends WithDsl[F] with FlowSyntax[F]:
+trait Process[F[_], In <: Event, Out <: Event] extends WithDsl[F] with FlowSyntax[F]:
   self =>
 
   /** Convenience alias for the program type produced by [[handle]] cases. */
@@ -106,15 +111,27 @@ trait Process[F[_], In <: Event] extends WithDsl[F] with FlowSyntax[F]:
       currentHandler = Some(newHandler)
     }
 
+  /** Sends `event` back to the sender of the message currently being handled.
+    *
+    * The type parameter is checked against this process's declared `Out` protocol. For example,
+    * `Process[F, Request, Response]` can reply with `Response`, but not with an unrelated event.
+    */
+  final protected def reply[E <: Out](event: => E): Program =
+    dsl.reply(event)
+
+  /** Sends each event back to the current sender, preserving order. */
+  final protected def reply[E <: Out](events: Seq[E]): Program =
+    dsl.reply(events)
+
   /** Alias for [[and]]. */
-  def ++[In2 <: In](that: Process[F, In2]): Process[F, In2] =
+  def ++[In2 <: In, Out2 <: Event](that: Process[F, In2, Out2]): Process[F, In2, Out | Out2] =
     and(that)
 
   /** Composes two processes so that an event is dispatched to *both* if both can handle it. Programs run sequentially
     * via `++`. The resulting process inherits this process's [[ref]] and [[name]].
     */
-  def and[In2 <: In](that: Process[F, In2]): Process[F, In2] =
-    new Process[F, In2]:
+  def and[In2 <: In, Out2 <: Event](that: Process[F, In2, Out2]): Process[F, In2, Out | Out2] =
+    new Process[F, In2, Out | Out2]:
       override val ref: ProcessRef[In2] = self.ref
       override val name: String         = self.name
 
@@ -129,8 +146,8 @@ trait Process[F[_], In <: Event] extends WithDsl[F] with FlowSyntax[F]:
   /** Composes two processes so that an event is dispatched to the first that can handle it. The resulting process
     * inherits this process's [[ref]] and [[name]].
     */
-  def or[In2 <: In](that: Process[F, In2]): Process[F, In2] =
-    new Process[F, In2]:
+  def or[In2 <: In, Out2 <: Event](that: Process[F, In2, Out2]): Process[F, In2, Out | Out2] =
+    new Process[F, In2, Out | Out2]:
       override val ref: ProcessRef[In2] = self.ref
       override val name: String         = self.name
 
@@ -148,8 +165,8 @@ trait Process[F[_], In <: Event] extends WithDsl[F] with FlowSyntax[F]:
 /** Constructors and ad-hoc builders for [[Process]]. */
 object Process:
   /** A no-op process that silently consumes any event. Useful as a placeholder or sink. */
-  def unit[F[_]]: Process[F, Event] =
-    new Process[F, Event]:
+  def unit[F[_]]: Process[F, Event, Nothing] =
+    new Process[F, Event, Nothing]:
       override def handle: Receive = { case _ => dsl.unit }
 
   /** Builds a process inline from a function that, given the process's ref, returns a receive partial function. The
@@ -157,25 +174,37 @@ object Process:
     */
   def apply[F[_]](
       receive: ProcessRef[Event] => PartialFunction[Event, DslF[F, Unit]]
-  ): Process[F, Event] =
+  ): Process[F, Event, Event] =
     builder(receive).build
 
   /** Builds a typed process inline from a function that accepts the process's typed ref. */
   def typed[F[_], In <: Event](
       receive: ProcessRef[In] => PartialFunction[In | SystemEvent, DslF[F, Unit]]
-  ): Process[F, In] =
+  ): Process[F, In, Event] =
     typedBuilder(receive).build
+
+  /** Builds a typed request/reply process inline from a function that accepts the process's typed ref. */
+  def replying[F[_], In <: Event, Out <: Event](
+      receive: ProcessRef[In] => PartialFunction[In | SystemEvent, DslF[F, Unit]]
+  ): Process[F, In, Out] =
+    replyingBuilder(receive).build
 
   /** Returns a [[Builder]] for fluent inline process construction. */
   def builder[F[_]](
       receive: ProcessRef[Event] => PartialFunction[Event, DslF[F, Unit]]
-  ): Builder[F, Event] =
+  ): Builder[F, Event, Event] =
     Builder(receive)
 
   /** Returns a typed [[Builder]] for fluent inline process construction. */
   def typedBuilder[F[_], In <: Event](
       receive: ProcessRef[In] => PartialFunction[In | SystemEvent, DslF[F, Unit]]
-  ): Builder[F, In] =
+  ): Builder[F, In, Event] =
+    Builder(receive)
+
+  /** Returns a typed request/reply [[Builder]] for fluent inline process construction. */
+  def replyingBuilder[F[_], In <: Event, Out <: Event](
+      receive: ProcessRef[In] => PartialFunction[In | SystemEvent, DslF[F, Unit]]
+  ): Builder[F, In, Out] =
     Builder(receive)
 
   /** Fluent constructor for inline processes. Configure the name, ref, and buffer size, then call [[build]] to
@@ -190,28 +219,28 @@ object Process:
     * @param processBufferSize
     *   mailbox capacity, or `-1` to use the global default.
     */
-  final case class Builder[F[_], In <: Event](
+  final case class Builder[F[_], In <: Event, Out <: Event](
       receive: ProcessRef[In] => PartialFunction[In | SystemEvent, DslF[F, Unit]],
       private val processName: String = "undefined",
       private val processRef: ProcessRef[In] = ProcessRef.jdkUUIDRef[In],
       private val processBufferSize: Int = -1
   ):
     /** Sets the process's display name. */
-    def name(value: String): Builder[F, In] =
+    def name(value: String): Builder[F, In, Out] =
       copy(processName = value)
 
     /** Pins the process to a specific [[ProcessRef]]. */
-    def ref(value: ProcessRef[In]): Builder[F, In] =
+    def ref(value: ProcessRef[In]): Builder[F, In, Out] =
       copy(processRef = value)
 
     /** Sets the mailbox capacity. Must be positive or `-1` (use default). */
-    def bufferSize(value: Int): Builder[F, In] =
+    def bufferSize(value: Int): Builder[F, In, Out] =
       require(value > 0 || value == -1)
       copy(processBufferSize = value)
 
     /** Materializes the configured [[Process]]. */
-    def build: Process[F, In] =
-      new Process[F, In]:
+    def build: Process[F, In, Out] =
+      new Process[F, In, Out]:
         override val name: String        = processName
         override val ref: ProcessRef[In] = processRef
         override val bufferSize: Int     = processBufferSize

--- a/parapet-core/src/main/scala/io/parapet/core/Scheduler.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Scheduler.scala
@@ -598,7 +598,7 @@ object Scheduler:
         Signal(envelope, context.createTrace(envelope.id))
 
     private def handleError[F[_]](
-        process: Process[F, ?],
+        process: Process[F, ?, ?],
         envelope: Envelope,
         context: Context[F],
         interpreter: Interpreter[F],

--- a/parapet-core/src/main/scala/io/parapet/core/processes/DeadLetterProcess.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/processes/DeadLetterProcess.scala
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
   * Override [[io.parapet.ParApp.deadLetter]] to substitute a custom implementation (metrics, alerting, persistence,
   * etc.).
   */
-trait DeadLetterProcess[F[_]] extends Process[F, DeadLetter]:
+trait DeadLetterProcess[F[_]] extends Process[F, DeadLetter, Nothing]:
   override val name: String                      = DeadLetterRef.value
   final override val ref: ProcessRef[DeadLetter] = DeadLetterRef
 

--- a/parapet-core/src/main/scala/io/parapet/core/processes/Noop.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/processes/Noop.scala
@@ -7,7 +7,7 @@ import io.parapet.core.Process
   * Registered automatically by the runtime under [[io.parapet.ProcessRef.NoopRef]] so user code can route messages to a
   * known sink (e.g., during shutdown) without producing dead-letter noise.
   */
-class Noop[F[_]] extends Process[F, io.parapet.Event] {
+class Noop[F[_]] extends Process[F, io.parapet.Event, Nothing] {
   override def handle: Receive = { case _ =>
     dsl.unit
   }

--- a/parapet-core/src/main/scala/io/parapet/core/processes/ProcessWithState.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/processes/ProcessWithState.scala
@@ -11,4 +11,4 @@ import io.parapet.core.Process
   * @param state
   *   initial state; the subclass owns its mutation discipline.
   */
-abstract class ProcessWithState[F[_], In <: Event, S](val state: S) extends Process[F, In]
+abstract class ProcessWithState[F[_], In <: Event, Out <: Event, S](val state: S) extends Process[F, In, Out]

--- a/parapet-core/src/main/scala/io/parapet/core/processes/Sub.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/processes/Sub.scala
@@ -14,7 +14,7 @@ import io.parapet.{Event, ProcessRef}
   * @param subs
   *   subscribers to forward events to.
   */
-class Sub[F[_]](subs: Seq[Subscription]) extends Process[F, Event] {
+class Sub[F[_]](subs: Seq[Subscription]) extends Process[F, Event, Event] {
 
   import dsl._
 

--- a/parapet-core/src/main/scala/io/parapet/core/processes/SystemProcess.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/processes/SystemProcess.scala
@@ -11,7 +11,7 @@ import io.parapet.core.Process
   * when the failed envelope's sender ref is itself unknown). The system process re-wraps the failure as a
   * [[DeadLetter]] and routes it to the [[DeadLetterProcess]].
   */
-class SystemProcess[F[_]] extends Process[F, Event] {
+class SystemProcess[F[_]] extends Process[F, Event, Event] {
 
   override val name: String           = SystemRef.value
   override val ref: ProcessRef[Event] = SystemRef

--- a/parapet-core/src/main/scala/io/parapet/syntax/EventSyntax.scala
+++ b/parapet-core/src/main/scala/io/parapet/syntax/EventSyntax.scala
@@ -18,7 +18,7 @@ trait EventSyntax[F[_]]:
       EventSyntax.send(List(event), process)
 
     /** Sends `event` to `process.ref`. */
-    def ~>(process: Process[F, ? >: E <: Event]): DslF[F, Unit] =
+    def ~>(process: Process[F, ? >: E <: Event, ?]): DslF[F, Unit] =
       EventSyntax.send(List(event), process.ref)
 
   extension [E <: Event](events: Seq[E])
@@ -27,7 +27,7 @@ trait EventSyntax[F[_]]:
       EventSyntax.send(events, process)
 
     /** Sends each of `events`, in order, to `process.ref`. */
-    def ~>(process: Process[F, ? >: E]): DslF[F, Unit] =
+    def ~>(process: Process[F, ? >: E, ?]): DslF[F, Unit] =
       EventSyntax.send(events, process.ref)
 
 /** Implementation backing [[EventSyntax]]. */

--- a/parapet-core/src/test/scala/io/parapet/core/ProcessSpec.scala
+++ b/parapet-core/src/test/scala/io/parapet/core/ProcessSpec.scala
@@ -1,6 +1,6 @@
 package io.parapet.core
 
-import io.parapet.Event
+import io.parapet.{Event, ProcessRef}
 import io.parapet.core.Dsl.WithDsl
 import io.parapet.core.Events.Start
 import org.scalatest.funsuite.AnyFunSuite
@@ -13,6 +13,8 @@ class ProcessSpec extends AnyFunSuite with WithDsl[TestUtils.Id]:
 
   sealed trait Command extends Event
   case object Ping     extends Command
+  case object Request  extends Event
+  case object Response extends Event
 
   test("and composes system event handlers for typed processes") {
     var seen = Vector.empty[String]
@@ -49,4 +51,20 @@ class ProcessSpec extends AnyFunSuite with WithDsl[TestUtils.Id]:
     composed.canHandle(Start) shouldBe true
     composed(Start).foldMap(new IdInterpreter())
     seen shouldBe Vector("lifecycle")
+  }
+
+  test("reply is checked against the process output protocol") {
+    val clientRef = ProcessRef[Response.type]("client")
+    val execution = new Execution()
+
+    val server = new Process[Id, Request.type, Response.type]:
+      import dsl.*
+
+      override def handle: Receive = { case Request =>
+        reply(Response)
+      }
+
+    server(Request).foldMap(new IdInterpreter(execution, senderRef = clientRef))
+
+    execution.trace.toSeq shouldBe Seq(Message(Response, clientRef))
   }

--- a/parapet-net/src/main/scala/io/parapet/net/processes/TcpClientProcess.scala
+++ b/parapet-net/src/main/scala/io/parapet/net/processes/TcpClientProcess.scala
@@ -4,7 +4,7 @@ import io.parapet.core.Events.Stop
 import io.parapet.core.Process
 import io.parapet.core.api.Cmd
 import io.parapet.net.RequestResponseClient
-import io.parapet.{ProcessRef, core}
+import io.parapet.{Event, ProcessRef, core}
 
 /** Adapter [[Process]] exposing a [[RequestResponseClient]] as an event-driven endpoint.
   *
@@ -20,7 +20,7 @@ import io.parapet.{ProcessRef, core}
 class TcpClientProcess[F[_]](
     client: RequestResponseClient[F],
     override val ref: ProcessRef[Cmd.netClient.Send] = ProcessRef[Cmd.netClient.Send]("net-tcp-client")
-) extends Process[F, Cmd.netClient.Send]:
+) extends Process[F, Cmd.netClient.Send, Event]:
 
   import dsl._
 

--- a/parapet-net/src/main/scala/io/parapet/net/processes/TcpServerProcess.scala
+++ b/parapet-net/src/main/scala/io/parapet/net/processes/TcpServerProcess.scala
@@ -4,7 +4,7 @@ import io.parapet.core.Events.{Start, Stop}
 import io.parapet.core.Process
 import io.parapet.core.api.Cmd
 import io.parapet.net.RequestResponseServer
-import io.parapet.{ProcessRef, core}
+import io.parapet.{Event, ProcessRef, core}
 
 /** Adapter [[Process]] exposing a [[RequestResponseServer]] as an event-driven endpoint.
   *
@@ -23,7 +23,7 @@ class TcpServerProcess[F[_]](
     server: RequestResponseServer[F],
     sink: ProcessRef[Cmd.netServer.Message],
     override val ref: ProcessRef[Cmd.netServer.Send] = ProcessRef[Cmd.netServer.Send]("net-tcp-server")
-) extends Process[F, Cmd.netServer.Send]:
+) extends Process[F, Cmd.netServer.Send, Event]:
 
   import dsl._
 

--- a/parapet-net/src/main/scala/io/parapet/net/processes/UdpBroadcastProcess.scala
+++ b/parapet-net/src/main/scala/io/parapet/net/processes/UdpBroadcastProcess.scala
@@ -3,7 +3,7 @@ package io.parapet.net.processes
 import io.parapet.core.Events.{Start, Stop}
 import io.parapet.core.Process
 import io.parapet.net.{DatagramTransport, UdpEvents}
-import io.parapet.{ProcessRef, core}
+import io.parapet.{Event, ProcessRef, core}
 
 import scala.concurrent.duration.*
 
@@ -29,7 +29,7 @@ class UdpBroadcastProcess[F[_]](
     pollLimit: Int = 16,
     pollDelay: FiniteDuration = 10.millis,
     override val ref: ProcessRef[UdpEvents.Send] = ProcessRef[UdpEvents.Send]("net-udp-broadcast")
-) extends Process[F, UdpEvents.Send]:
+) extends Process[F, UdpEvents.Send, Event]:
 
   import dsl._
 

--- a/parapet-pario/src/main/scala/io/parapet/ParIOApp.scala
+++ b/parapet-pario/src/main/scala/io/parapet/ParIOApp.scala
@@ -9,7 +9,7 @@ import io.parapet.core.SchedulerRuntime
   *
   * {{{
   * object Main extends ParIOApp:
-  *   def processes(args: Array[String]): ParIO[Seq[Process[ParIO]]] =
+  *   def processes(args: Array[String]): ParIO[Seq[Process[ParIO, ?, ?]]] =
   *     ParIO.pure(Seq(new MyProcess))
   * }}}
   */

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/BasicParIOSpec.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/BasicParIOSpec.scala
@@ -9,20 +9,20 @@ trait BasicParIOSpec extends IntegrationSpec[ParIO] with ParIOApp {
   self =>
 
   override def createApp(
-      processes0: ParIO[Seq[core.Process[ParIO, ?]]],
+      processes0: ParIO[Seq[core.Process[ParIO, ?, ?]]],
       deadLetter0: Option[ParIO[DeadLetterProcess[ParIO]]],
       config0: Parapet.ParConfig
   ): ParApp[ParIO] =
     new ParIOApp {
       override val config: Parapet.ParConfig = config0
 
-      override def processes(args: Array[String]): ParIO[Seq[core.Process[ParIO, ?]]] =
+      override def processes(args: Array[String]): ParIO[Seq[core.Process[ParIO, ?, ?]]] =
         processes0
 
       override def deadLetter: ParIO[DeadLetterProcess[ParIO]] =
         deadLetter0.getOrElse(super.deadLetter)
     }
 
-  override def processes(args: Array[String]): ParIO[Seq[core.Process[ParIO, ?]]] =
+  override def processes(args: Array[String]): ParIO[Seq[core.Process[ParIO, ?, ?]]] =
     ParIO.pure(Seq.empty)
 }

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/ParIOSpecs.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/ParIOSpecs.scala
@@ -85,19 +85,19 @@ class BlockingChannelWithTimeout extends AnyFunSuite with BasicParIOSpec:
   test("blockingChannelTimeout") {
     val eventStore = new EventStore[ParIO, Event]
 
-    val server = Process
-      .builder[ParIO](_ => { case e: ByteEvent =>
+    val server = new Process[ParIO, Event, ByteEvent] {
+      override val ref = ProcessRef("server")
+
+      override def handle: Receive = { case e: ByteEvent =>
         eval(println(s"server received: $e")) ++
           delay(10.seconds) ++
-          withSender(sender => ByteEvent("res".getBytes) ~> sender)
-      })
-      .ref(ProcessRef("server"))
-      .build
+          reply(ByteEvent("res".getBytes))
+      }
+    }
 
     val failover = Process
       .builder[ParIO](ref => { case e: ByteEvent =>
-        withSender(sender => eval(println(s"failover received: $e from $sender"))) ++
-          eval(eventStore.add(ref, StringEvent("success")))
+        eval(println(s"failover received: $e")) ++ eval(eventStore.add(ref, StringEvent("success")))
       })
       .ref(ProcessRef("failover"))
       .build

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
@@ -25,15 +25,16 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
 
     val numOfRequests = 5
 
-    val server = Process
-      .builder[F](_ => { case Request(seq) =>
-        withSender(sender => Response(seq) ~> sender)
-      })
-      .name("server")
-      .ref(ProcessRef("server"))
-      .build
+    val server = new Process[F, Event, Event] {
+      override val name = "server"
+      override val ref  = ProcessRef("server")
 
-    val client: Process[F, Event] = new Process[F, Event] {
+      override def handle: Receive = { case Request(seq) =>
+        reply(Response(seq))
+      }
+    }
+
+    val client: Process[F, Event, Event] = new Process[F, Event, Event] {
       override val name = "client"
       override val ref  = ProcessRef("client")
       var seq           = 0
@@ -77,18 +78,15 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
 
     val ch = Channel[F]
 
-    val server = new Process[F, Event] {
+    val server = new Process[F, Event, Event] {
       override val ref: ProcessRef[Event] = serverRef
 
       override def handle: Receive = { case req @ Request(seq) =>
-        withSender { sender =>
-          eval(eventStore.add(ch.ref, req)) ++
-            Response(seq + 1) ~> sender
-        }
+        eval(eventStore.add(ch.ref, req)) ++ reply(Response(seq + 1))
       }
     }
 
-    val client = new Process[F, Event] {
+    val client = new Process[F, Event, Event] {
       override val ref: ProcessRef[Event] = clientRef
 
       override def handle: Receive = { case Start =>

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/DslSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/DslSpec.scala
@@ -69,7 +69,7 @@ abstract class DslSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
       "be delivered to all receivers in specified order" in {
         val eventStore = new EventStore[F, Request]
 
-        def createServer(addr: String): Process[F, Event] = Process[F](ref => { case req: Request =>
+        def createServer(addr: String): Process[F, Event, Event] = Process[F](ref => { case req: Request =>
           eval(eventStore.add(ref, Request(s"$addr-${req.body}")))
         })
 
@@ -88,20 +88,19 @@ abstract class DslSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
     }
   }
 
-  "withSender callback function" when {
+  "reply operator" when {
     "event received" should {
-      "pass sender ref to the callback function" in {
+      "send the event back to the sender" in {
 
         val eventStore = new EventStore[F, Response]
 
-        val server = Process[F](_ => { case Request(data) =>
-          for {
-            sender <- withSender(sender => eval(sender))
-            _      <- Response(s"echo-$data") ~> sender
-          } yield ()
-        })
+        val server = new Process[F, Event, Response] {
+          override def handle: Receive = { case Request(data) =>
+            reply(Response(s"echo-$data"))
+          }
+        }
 
-        val client: Process[F, Event] = Process[F](ref => {
+        val client: Process[F, Event, Event] = Process[F](ref => {
           case Start         => Request("hello") ~> server
           case res: Response => eval(eventStore.add(ref, res))
         })
@@ -119,11 +118,13 @@ abstract class DslSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
 
         val eventStore = new EventStore[F, Response]
 
-        val server = Process[F](_ => { case Request(data) =>
-          reply(Response(s"echo-$data"))
-        })
+        val server = new Process[F, Event, Response] {
+          override def handle: Receive = { case Request(data) =>
+            reply(Response(s"echo-$data"))
+          }
+        }
 
-        val client: Process[F, Event] = Process[F](ref => {
+        val client: Process[F, Event, Event] = Process[F](ref => {
           case Start         => Request("hello") ~> server
           case res: Response => eval(eventStore.add(ref, res))
         })
@@ -141,11 +142,13 @@ abstract class DslSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
 
         val eventStore = new EventStore[F, Response]
 
-        val server = Process[F](_ => { case Request(data) =>
-          reply(Seq(Response(s"1-$data"), Response(s"2-$data"), Response(s"3-$data")))
-        })
+        val server = new Process[F, Event, Response] {
+          override def handle: Receive = { case Request(data) =>
+            reply(Seq(Response(s"1-$data"), Response(s"2-$data"), Response(s"3-$data")))
+          }
+        }
 
-        val client: Process[F, Event] = Process
+        val client: Process[F, Event, Event] = Process
           .builder[F](ref => {
             case Start         => Request("x") ~> server
             case res: Response => eval(eventStore.add(ref, res))
@@ -242,26 +245,29 @@ abstract class DslSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
   "Event" when {
     "send using forward" should {
       "be delivered to a receiver with original sender reference" in {
-        val eventStore = new EventStore[F, Request]
+        val eventStore = new EventStore[F, Response]
 
-        val server: Process[F, Event] = Process[F](ref => { case Request(body) =>
-          withSender(sender => eval(eventStore.add(ref, Request(s"$sender-$body"))))
-        })
+        val server: Process[F, Event, Response] = new Process[F, Event, Response] {
+          override def handle: Receive = { case Request(body) =>
+            reply(Response(s"echo-$body"))
+          }
+        }
 
-        val proxy: Process[F, Event] = Process[F](_ => { case Request(body) =>
+        val proxy: Process[F, Event, Event] = Process[F](_ => { case Request(body) =>
           forward(Request(s"proxy-$body"), server.ref)
         })
 
-        val client: Process[F, Event] = Process
-          .builder[F](_ => { case Start =>
-            Request("ping") ~> proxy
+        val client: Process[F, Event, Event] = Process
+          .builder[F](ref => {
+            case Start         => Request("ping") ~> proxy
+            case res: Response => eval(eventStore.add(ref, res))
           })
           .ref(ProcessRef("client"))
           .build
 
         unsafeRun(eventStore.await(1, createApp(ct.pure(Seq(client, server, proxy))).run))
 
-        eventStore.get(server.ref).headOption.value shouldBe Request(s"client-proxy-ping")
+        eventStore.get(client.ref).headOption.value shouldBe Response("echo-proxy-ping")
       }
     }
   }
@@ -272,7 +278,7 @@ abstract class DslSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
 
         val eventStore = new EventStore[F, IntEvent]
 
-        val process: Process[F, Event] = Process[F] { ref =>
+        val process: Process[F, Event, Event] = Process[F] { ref =>
           def times(n: Int): DslF[F, Unit] = {
             def step(remaining: Int): DslF[F, Unit] = flow {
               if (remaining == 0) unit
@@ -302,7 +308,7 @@ abstract class DslSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
 
         val longRunningTask = delay(1.minute)
 
-        val process: Process[F, Event] = Process[F](ref => { case Start =>
+        val process: Process[F, Event, Event] = Process[F](ref => { case Start =>
           fork(longRunningTask) ++ eval(eventStore.add(ref, Request("end")))
         })
 
@@ -320,7 +326,7 @@ abstract class DslSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
 
         val longRunningTask = delay(10.minutes)
 
-        val process: Process[F, Event] = Process[F](ref => { case Start =>
+        val process: Process[F, Event, Event] = Process[F](ref => { case Start =>
           for {
             res <- race(longRunningTask, eval("now"))
             _   <- res match {
@@ -341,7 +347,7 @@ abstract class DslSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
 
         val failure = eval(throw new RuntimeException("server failed"))
 
-        val process: Process[F, Event] = Process[F](ref => { case Start =>
+        val process: Process[F, Event, Event] = Process[F](ref => { case Start =>
           failure.handleError((err: Throwable) => eval(eventStore.add(ref, Response(err))))
         })
         unsafeRun(eventStore.await(1, createApp(ct.pure(Seq(process))).run))
@@ -372,7 +378,7 @@ abstract class DslSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
           step ++ loop
         }
 
-        val process: Process[F, Event] = Process
+        val process: Process[F, Event, Event] = Process
           .builder[F](_ => { case Start =>
             fork(loop).map(_ => ())
           })

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/DynamicProcessCreationSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/DynamicProcessCreationSpec.scala
@@ -36,7 +36,7 @@ abstract class DynamicProcessCreationSpec[F[_]] extends AnyFunSuite with Integra
 object DynamicProcessCreationSpec {
 
   class Worker[F[_]](id: Int, db: ProcessRef[Event], tasksCount: Int, eventStore: EventStore[F, Event])
-      extends Process[F, Event] {
+      extends Process[F, Event, Event] {
 
     import dsl._
 
@@ -51,17 +51,17 @@ object DynamicProcessCreationSpec {
     }
   }
 
-  class Database[F[_]] extends Process[F, Event] {
+  class Database[F[_]] extends Process[F, Event, Event] {
 
     import dsl._
 
     override def handle: Receive = { case Persist(id) =>
-      withSender(sender => Ack(id) ~> sender)
+      reply(Ack(id))
     }
   }
 
   class Server[F[_]](workersCount: Int, db: ProcessRef[Event], tasksCount: Int, eventStore: EventStore[F, Event])
-      extends Process[F, Event] {
+      extends Process[F, Event, Event] {
 
     import dsl._
 

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ErrorHandlingSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ErrorHandlingSpec.scala
@@ -22,14 +22,11 @@ abstract class ErrorHandlingSpec[F[_]] extends AnyWordSpec with IntegrationSpec[
 
         val faultyServer = createFaultyServer[F]
 
-        val client = new Process[F, Event] {
+        val client = new Process[F, Event, Event] {
           def handle: Receive = {
             case Start      => Request ~> faultyServer
             case f: Failure =>
-              withSender { sender =>
-                sender shouldBe ProcessRef.SystemRef
-                eval(clientEventStore.add(ref, f))
-              }
+              eval(clientEventStore.add(ref, f))
           }
         }
 
@@ -52,12 +49,12 @@ abstract class ErrorHandlingSpec[F[_]] extends AnyWordSpec with IntegrationSpec[
             eval(eventStore.add(ref, f))
           }
         }
-        val server = new Process[F, Event] {
+        val server = new Process[F, Event, Event] {
           def handle: Receive = { case Request =>
             eval(throw new RuntimeException("server is down"))
           }
         }
-        val client = new Process[F, Event] {
+        val client = new Process[F, Event, Event] {
           def handle: Receive = { case Start =>
             Request ~> server
           }
@@ -83,12 +80,12 @@ abstract class ErrorHandlingSpec[F[_]] extends AnyWordSpec with IntegrationSpec[
             eval(eventStore.add(ref, f))
           }
         }
-        val server = new Process[F, Event] {
+        val server = new Process[F, Event, Event] {
           def handle: Receive = { case Request =>
             eval(throw new RuntimeException("server is down"))
           }
         }
-        val client = new Process[F, Event] {
+        val client = new Process[F, Event, Event] {
           def handle: Receive = {
             case Start      => Request ~> server
             case _: Failure => eval(throw new RuntimeException("client failed to handle error"))
@@ -109,7 +106,7 @@ abstract class ErrorHandlingSpec[F[_]] extends AnyWordSpec with IntegrationSpec[
 
 object ErrorHandlingSpec {
 
-  def createFaultyServer[F[_]]: Process[F, Event] = new Process[F, Event] {
+  def createFaultyServer[F[_]]: Process[F, Event, Event] = new Process[F, Event, Event] {
 
     import dsl._
 

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/EventDeliverySpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/EventDeliverySpec.scala
@@ -107,13 +107,13 @@ abstract class EventDeliverySpec[F[_]] extends AnyFlatSpec with IntegrationSpec[
       }
     }
 
-    val server = new Process[F, Event] {
+    val server = new Process[F, Event, Event] {
       def handle: Receive = { case Start =>
         unit
       }
     }
 
-    val client = new Process[F, Event] {
+    val client = new Process[F, Event, Event] {
       def handle: Receive = { case Start =>
         UnknownEvent ~> server
       }
@@ -137,9 +137,12 @@ object EventDeliverySpec {
 
   case class NumEvent(i: Int) extends Event
 
-  def createProcesses[F[_]](numOfProcesses: Int, eventStore: EventStore[F, QualifiedEvent]): Seq[Process[F, Event]] =
+  def createProcesses[F[_]](
+      numOfProcesses: Int,
+      eventStore: EventStore[F, QualifiedEvent]
+  ): Seq[Process[F, Event, Event]] =
     (0 until numOfProcesses).map { i =>
-      new Process[F, Event] {
+      new Process[F, Event, Event] {
 
         import dsl._
 

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/IntegrationSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/IntegrationSpec.scala
@@ -43,12 +43,12 @@ trait IntegrationSpec[F[_]] extends WithDsl[F] with FlowSyntax[F] with ParApp[F]
   }
 
   def createApp(
-      processes0: F[Seq[Process[F, ?]]],
+      processes0: F[Seq[Process[F, ?, ?]]],
       deadLetter0: Option[F[DeadLetterProcess[F]]] = None,
       config0: ParConfig = ParConfig.default
   ): ParApp[F]
 
-  def onStart(program: DslF[F, Unit]): Process[F, Event] =
+  def onStart(program: DslF[F, Unit]): Process[F, Event, Event] =
     Process
       .builder[F](_ => { case Start =>
         program

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ProcessBehaviourSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ProcessBehaviourSpec.scala
@@ -12,8 +12,8 @@ abstract class ProcessBehaviourSpec[F[_]] extends AnyFunSuite with IntegrationSp
   import dsl._
 
   test("switch behaviour") {
-    val eventStore                 = new EventStore[F, Event]
-    val process: Process[F, Event] = new Process[F, Event] {
+    val eventStore                        = new EventStore[F, Event]
+    val process: Process[F, Event, Event] = new Process[F, Event, Event] {
 
       def uninitialized: Receive = { case Init =>
         eval(eventStore.add(ref, Init)) ++ switch(ready)

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ProcessLifecycleSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ProcessLifecycleSpec.scala
@@ -18,7 +18,7 @@ abstract class ProcessLifecycleSpec[F[_]] extends AnyFlatSpec with IntegrationSp
   "Start event" should "be delivered before client events" in {
     val expectedEventsCount = 2
     val eventStore          = new EventStore[F, Event]
-    val process             = new Process[F, Event] {
+    val process             = new Process[F, Event, Event] {
       def handle: Receive = {
         case Start     => eval(eventStore.add(ref, Start))
         case TestEvent => eval(eventStore.add(ref, TestEvent))
@@ -38,7 +38,7 @@ abstract class ProcessLifecycleSpec[F[_]] extends AnyFlatSpec with IntegrationSp
     val domainEventsCount = 1
     val totalEventsCount  = 2 // domainEventsCount + Stop
     val eventStore        = new EventStore[F, Event]
-    val process           = new Process[F, Event] {
+    val process           = new Process[F, Event, Event] {
       def handle: Receive = {
         case TestEvent => eval(eventStore.add(ref, TestEvent))
         case Stop      => eval(eventStore.add(ref, Stop))
@@ -58,28 +58,28 @@ abstract class ProcessLifecycleSpec[F[_]] extends AnyFlatSpec with IntegrationSp
 
     val lastProcessCreated = new AtomicBoolean()
 
-    val parent = new Process[F, Event] {
+    val parent = new Process[F, Event, Event] {
       override val ref: ProcessRef[Event] = ProcessRef("a")
 
       override def handle: Receive = {
         case Start =>
           register(
             ref,
-            new Process[F, Event] {
+            new Process[F, Event, Event] {
               override val ref: ProcessRef[Event] = ProcessRef("b")
 
               override def handle: Receive = {
                 case Start =>
                   register(
                     ref,
-                    new Process[F, Event] {
+                    new Process[F, Event, Event] {
                       override val ref: ProcessRef[Event] = ProcessRef("c")
 
                       override def handle: Receive = {
                         case Start =>
                           register(
                             ref,
-                            new Process[F, Event] {
+                            new Process[F, Event, Event] {
                               override val ref: ProcessRef[Event] = ProcessRef("d")
 
                               override def handle: Receive = {
@@ -124,7 +124,7 @@ abstract class ProcessLifecycleSpec[F[_]] extends AnyFlatSpec with IntegrationSp
       })
       .build
 
-    val process: Process[F, Event] = Process[F](ref => { case Start =>
+    val process: Process[F, Event, Event] = Process[F](ref => { case Start =>
       register(ref, child) ++ TestEvent ~> child
     })
     unsafeRun(eventStore.await(1, createApp(ct.pure(Seq(process))).run))
@@ -137,7 +137,7 @@ abstract class ProcessLifecycleSpec[F[_]] extends AnyFlatSpec with IntegrationSp
   // todo freezing
 //  "Kill process" should "immediately terminates process and delivers Stop event" in {
 //    val eventStore = new EventStore[F, Event]
-//    val longRunningProcess: Process[F, Event] = new Process[F, Event] {
+//    val longRunningProcess: Process[F, Event, Event] = new Process[F, Event, Event] {
 //      override val ref: ProcessRef = ProcessRef("longRunningProcess")
 //
 //      override def handle: Receive = {
@@ -158,8 +158,8 @@ abstract class ProcessLifecycleSpec[F[_]] extends AnyFlatSpec with IntegrationSp
 //  }
 
   "Stop" should "deliver Stop event and remove process" in {
-    val eventStore                 = new EventStore[F, Event]
-    val process: Process[F, Event] = new Process[F, Event] {
+    val eventStore                        = new EventStore[F, Event]
+    val process: Process[F, Event, Event] = new Process[F, Event, Event] {
       override val ref: ProcessRef[Event] = ProcessRef("process")
 
       override def handle: Receive = { case e =>
@@ -194,7 +194,7 @@ abstract class ProcessLifecycleSpec[F[_]] extends AnyFlatSpec with IntegrationSp
   //      }
   //    }
   //
-  //    val process: Process[F, Event] = new Process[F, Event] {
+  //    val process: Process[F, Event, Event] = new Process[F, Event, Event] {
   //      override val ref: ProcessRef = ProcessRef("process")
   //
   //      override def handle: Receive = {
@@ -216,7 +216,7 @@ abstract class ProcessLifecycleSpec[F[_]] extends AnyFlatSpec with IntegrationSp
   //      }
   //    }
   //
-  //    val process: Process[F, Event] = new Process[F, Event] {
+  //    val process: Process[F, Event, Event] = new Process[F, Event, Event] {
   //      override def handle: Receive = {
   //        case _ => unit
   //      }

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ProcessSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ProcessSpec.scala
@@ -18,13 +18,13 @@ abstract class ProcessSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
   "A process p1 composed with process p2 using `or`" when {
     "p1 can't match event" should {
       "invoke p2" in {
-        val eventStore            = new EventStore[F, Event]
-        val p1: Process[F, Event] = new Process[F, Event] {
+        val eventStore                   = new EventStore[F, Event]
+        val p1: Process[F, Event, Event] = new Process[F, Event, Event] {
           override val handle: Receive = { case Start =>
             unit
           }
         }
-        val p2: Process[F, Event] = new Process[F, Event] {
+        val p2: Process[F, Event, Event] = new Process[F, Event, Event] {
           override val handle: Receive = { case r: Result =>
             eval(eventStore.add(ref, r))
           }
@@ -46,13 +46,13 @@ abstract class ProcessSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
   "A two processes p1 and p2 composed using `and`" when {
     "both defined for event X" should {
       "deliver event X" in {
-        val eventStore            = new EventStore[F, Event]
-        val p1: Process[F, Event] = new Process[F, Event] {
+        val eventStore                   = new EventStore[F, Event]
+        val p1: Process[F, Event, Event] = new Process[F, Event, Event] {
           override val handle: Receive = { case r: Result =>
             eval(eventStore.add(ref, r))
           }
         }
-        val p2: Process[F, Event] = new Process[F, Event] {
+        val p2: Process[F, Event, Event] = new Process[F, Event, Event] {
           override val handle: Receive = { case r: Result =>
             eval(eventStore.add(ref, r))
           }
@@ -82,12 +82,12 @@ abstract class ProcessSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
             eval(eventStore.add(ref, f))
           }
         }
-        val p1: Process[F, Event] = new Process[F, Event] {
+        val p1: Process[F, Event, Event] = new Process[F, Event, Event] {
           override val handle: Receive = { case Start =>
             unit
           }
         }
-        val p2: Process[F, Event] = new Process[F, Event] {
+        val p2: Process[F, Event, Event] = new Process[F, Event, Event] {
           override val handle: Receive = { case Start =>
             unit
           }
@@ -111,14 +111,14 @@ abstract class ProcessSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
 
 object ProcessSpec {
 
-  class Multiplier[F[_]] extends Process[F, Event] {
+  class Multiplier[F[_]] extends Process[F, Event, Event] {
 
     import dsl._
 
     override val ref: ProcessRef[Event] = Multiplier.ref
 
     override val handle: Receive = { case Multiply(a, b) =>
-      withSender(sender => Result(a * b) ~> sender)
+      reply(Result(a * b))
     }
   }
 

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ReplySpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ReplySpec.scala
@@ -15,13 +15,13 @@ abstract class ReplySpec[F[_]] extends AnyFlatSpec with IntegrationSpec[F] {
 
   "Reply" should "send send event to the sender" in {
     val clientEventStore = new EventStore[F, Event]
-    val server           = new Process[F, Event] {
+    val server           = new Process[F, Event, Event] {
       def handle: Receive = { case Request =>
-        withSender(sender => Response ~> sender)
+        reply(Response)
       }
     }
 
-    val client = new Process[F, Event] {
+    val client = new Process[F, Event, Event] {
       def handle: Receive = {
         case Start    => Request ~> server
         case Response => eval(clientEventStore.add(ref, Response))

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/SelfSendSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/SelfSendSpec.scala
@@ -16,7 +16,7 @@ abstract class SelfSendSpec[F[_]] extends AnyFlatSpec with IntegrationSpec[F] {
     val eventStore = new EventStore[F, Counter]
     val count      = 11000
 
-    val process = new Process[F, Event] {
+    val process = new Process[F, Event, Event] {
       def handle: Receive = {
         case Start          => Counter(count) ~> ref
         case c @ Counter(i) =>

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/SwitchBehaviorSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/SwitchBehaviorSpec.scala
@@ -51,7 +51,7 @@ object SwitchBehaviorSpec {
       initial: PartialFunction[Event, DslF[F, Unit]],
       es: EventStore[F, Event],
       override val ref: ProcessRef[Event]
-  ) extends Process[F, Event] {
+  ) extends Process[F, Event, Event] {
     self =>
 
     import dsl._
@@ -78,7 +78,7 @@ object SwitchBehaviorSpec {
       }
 
     def onSwitch: Receive = { case Switch(s) =>
-      switch(s) ++ withSender(Ok ~> _)
+      switch(s) ++ reply(Ok)
     }
 
     override def handle: Receive = onSwitch.orElse(initial)

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/scheduler/SchedulerSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/scheduler/SchedulerSpec.scala
@@ -29,13 +29,13 @@ abstract class SchedulerSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
           }
         }
 
-        val unknownProcess = new Process[F, Event] {
+        val unknownProcess = new Process[F, Event, Event] {
           def handle: Receive = { case _ =>
             unit
           }
         }
 
-        val client = new Process[F, Event] {
+        val client = new Process[F, Event, Event] {
           def handle: Receive = { case Start =>
             Request ~> unknownProcess
           }
@@ -64,13 +64,13 @@ abstract class SchedulerSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
           }
         }
 
-        val slowServer = new Process[F, Event] {
+        val slowServer = new Process[F, Event, Event] {
           override def handle: Receive = { case _: NamedRequest =>
             eval(while (true) {})
           }
         }
 
-        val client = new Process[F, Event] {
+        val client = new Process[F, Event, Event] {
           override def handle: Receive = { case Start =>
             NamedRequest("1") ~> slowServer ++
               delay(5.seconds) ++ NamedRequest("2") ~> slowServer ++ NamedRequest("3") ~> slowServer

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/scheduler/TestProcesses.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/scheduler/TestProcesses.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.FiniteDuration
   */
 object TestProcesses {
 
-  def dummy[F[_]]: Process[F, Event] = new Process[F, Event] {
+  def dummy[F[_]]: Process[F, Event, Event] = new Process[F, Event, Event] {
     import dsl._
     override val handle: Receive = { case _ => unit }
   }
@@ -28,8 +28,8 @@ object TestProcesses {
       eventStore: EventStore[F, TestEvent],
       time: FiniteDuration = TaskProcessingTime.instant.time,
       blockingHandler: Boolean
-  ): Process[F, Event] =
-    new Process[F, Event] {
+  ): Process[F, Event, Event] =
+    new Process[F, Event, Event] {
       import dsl._
       val handle: Receive = { case e: TestEvent =>
         val body = delay(time) ++ eval(eventStore.add(ref, e))
@@ -53,8 +53,8 @@ object TestProcesses {
       workload: WorkloadProfile,
       eventStore: EventStore[F, TestEvent],
       blockingRatio: Double = 0.0
-  ): Array[Process[F, Event]] = {
-    val processes = new Array[Process[F, Event]](n)
+  ): Array[Process[F, Event, Event]] = {
+    val processes = new Array[Process[F, Event, Event]](n)
     val blocking  = blockingIndexes(n, blockingRatio)
     (0 until n).foreach { i =>
       processes(i) = create(eventStore, WorkloadProfile.timeFor(workload, i, n).time, blocking.contains(i))

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/scheduler/WorkDistributionStrategy.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/scheduler/WorkDistributionStrategy.scala
@@ -12,7 +12,7 @@ trait WorkDistributionStrategy {
 
   /** Produces `Deliver` tasks.
     */
-  def createTasks[F[_]](n: Int, processes: Array[Process[F, Event]], numberOfSubmitters: Int): Seq[Deliver[F]]
+  def createTasks[F[_]](n: Int, processes: Array[Process[F, Event, Event]], numberOfSubmitters: Int): Seq[Deliver[F]]
 }
 
 object WorkDistributionStrategy {
@@ -24,7 +24,7 @@ object WorkDistributionStrategy {
 
     override def createTasks[F[_]](
         n: Int,
-        processes: Array[Process[F, Event]],
+        processes: Array[Process[F, Event, Event]],
         numberOfSubmitters: Int
     ): Seq[Deliver[F]] = {
       val submitters = math.max(1, numberOfSubmitters)
@@ -47,7 +47,7 @@ object WorkDistributionStrategy {
 
     override def createTasks[F[_]](
         n: Int,
-        processes: Array[Process[F, Event]],
+        processes: Array[Process[F, Event, Event]],
         numberOfSubmitters: Int
     ): Seq[Deliver[F]] = {
       val submitters = math.max(1, numberOfSubmitters)
@@ -75,7 +75,7 @@ object WorkDistributionStrategy {
 
     override def createTasks[F[_]](
         n: Int,
-        processes: Array[Process[F, Event]],
+        processes: Array[Process[F, Event, Event]],
         numberOfSubmitters: Int
     ): Seq[Deliver[F]] = {
       val submitters = math.max(1, numberOfSubmitters)


### PR DESCRIPTION
Adds an output protocol type to `Process[F, In, Out]` so process replies can be checked at compile time. Public process code now uses typed reply methods constrained by Out: reply/forward. DSL `reply` and `withSender` are priviate to parapet core