### PR TITLE
typed channel + timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ import io.parapet.{Event, ProcessRef}
 import io.parapet.core.{Channel, Process}
 import io.parapet.core.Events.Start
 import io.parapet.effect.Effect
+import scala.concurrent.duration.*
 
 final case class Request(data: String) extends Event
 final case class Response(data: String) extends Event
@@ -245,15 +246,15 @@ class Server[F[_]] extends Process[F, Request, Response]:
 
 class Client[F[_]: Effect](backend: ProcessRef[Request]) extends Process[F, Event, Nothing]:
   import dsl.*
-  private lazy val ch = Channel[F]()
+  private lazy val ch = Channel[F, Request, Response]
 
   override def handle: Receive =
     case Start =>
       register(ref, ch) ++
-        ch.send(Request("PING"), backend, {
+        ch.send(Request("PING"), backend, 3.seconds).flatMap {
           case scala.util.Success(Response(d)) => eval(println(d))
           case scala.util.Failure(err)         => eval(println(s"failed: ${err.getMessage}"))
-        })
+        }
 ```
 
 ## Error handling

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Combine programs with `++` (sequential composition) - e.g. `eval(println("a")) +
 ## Channel - request/response
 
 `Channel` turns the asynchronous mailbox model into a strict one-call-at-a-time
-request/reply dialog. Send through it, get a `Try[Event]` back.
+request/reply dialog. Send through it, get a typed `Try[Out]` response back.
 
 ```scala
 import io.parapet.{Event, ProcessRef}

--- a/parapet-core/src/main/scala/io/parapet/core/Channel.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Channel.scala
@@ -6,7 +6,6 @@ import io.parapet.effect.{Deferred, Effect}
 import io.parapet.effect.Monad.*
 import io.parapet.{Event, ProcessRef}
 
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
@@ -44,25 +43,27 @@ class Channel[F[_], In <: Event, Out <: Event](
   private val runtimeDsl = summon[Dsl.RuntimeOps.Aux[F]]
   import runtimeDsl.*
 
+  // `inFlight` is mutated from two contexts:
+  //   (a) the channel's own handler (single-threaded by construction);
+  //   (b) `send`, while holding `lockProcess(ref)`
   private var inFlight: Option[InFlight[F, Out]] = None
-  private val debugCallNumber                    = new AtomicInteger()
   private val requestIds                         = new AtomicLong()
-  private val debugMode                          = false
 
   private def waitForRequest: Receive = {
     case req: Request[F, Out] @unchecked => sendReq(req)
-    case Timeout(_)                      => unit
+    // Swallow stray events: late `Timeout(_)` from a fiber that lost the cancel race, and stale replies that
+    // arrive after the channel has already timed out and reset. Without this, the runtime would dead-letter
+    // them with a WARN per stray event.
+    case _ => unit
   }
 
   private def waitForResponse: Receive = {
     case Start => unit
     case Stop  =>
-      flow {
-        inFlight match
-          case Some(active) =>
-            complete(active, scala.util.Failure(ChannelInterruptedException("channel has been closed")))
-          case None => unit
-      }
+      inFlight match
+        case Some(active) =>
+          complete(active, scala.util.Failure(ChannelInterruptedException("channel has been closed")))
+        case None => unit
     case req: Request[F, Out] @unchecked =>
       suspend(
         req.result
@@ -84,9 +85,7 @@ class Channel[F[_], In <: Event, Out <: Event](
       withSender { sender =>
         inFlight match
           case Some(active) if active.receiver == sender =>
-            debug(
-              s"resetAndWaitForRequest, event: $event"
-            ) ++ completeAndReset(active, castResponse(event))
+            completeAndReset(active, castResponse(event))
           case Some(active) =>
             completeAndReset(
               active,
@@ -150,7 +149,7 @@ class Channel[F[_], In <: Event, Out <: Event](
     }.flatMap {
       case true =>
         req.timeout.fold(unit)(timeout => fork(delay(timeout) ++ Timeout(req.id) ~> ref).void) ++
-          debug("waitForResponse") ++ switch(waitForResponse) ++
+          switch(waitForResponse) ++
           dsl.send(ref, req.event, req.receiver.asInstanceOf[ProcessRef[Event]])
       case false =>
         suspend(
@@ -175,14 +174,6 @@ class Channel[F[_], In <: Event, Out <: Event](
 
   private def completeAndReset(active: InFlight[F, Out], result: Try[Out]): DslF[F, Unit] =
     resetAndWaitForRequest ++ complete(active, result)
-
-  private def debug(message: => String): DslF[F, Unit] =
-    if debugMode then
-      eval {
-        val number = debugCallNumber.incrementAndGet()
-        println(s"channel[$ref, $number]: $message")
-      }
-    else unit
 
 /** Constructors and exceptions for [[Channel]]. */
 object Channel:

--- a/parapet-core/src/main/scala/io/parapet/core/Channel.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Channel.scala
@@ -21,9 +21,34 @@ import scala.util.Try
   * Callers typically construct a channel, register it under their own process, and use [[send]] to obtain a `Try[Out]`
   * representing the eventual reply.
   *
-  * `Channel` is intentionally not a reliable-delivery or correlated-RPC abstraction. It waits for the next response
-  * from the active receiver; if a timed-out receiver later replies while another request to the same receiver is in
-  * flight, the application protocol must distinguish that stale reply. TODO
+  * `Channel` is not a correlated-RPC abstraction: replies are matched only by the active receiver's ref, not by a
+  * per-request id. Without a correlation id, a late reply from the same receiver cannot be distinguished from the
+  * reply to the current in-flight request, so a stale reply can complete the wrong caller. Example:
+  *
+  * {{{
+  * T+0ms     channel.send(Req1, server, timeout = 100.millis)
+  *             -> inFlight = Some(id = 1, receiver = server)
+  *             -> state = waitForResponse
+  *             -> envelope Req1 dispatched to server
+  *             -> fork(delay(100.millis) ++ Timeout(1) ~> channel)
+  *
+  * T+100ms   Timeout(1) arrives at channel
+  *             -> active.id == 1, match
+  *             -> caller's Deferred completes with ChannelTimeoutException
+  *             -> resetAndWaitForRequest clears inFlight, switches to waitForRequest
+  *
+  * T+150ms   channel.send(Req2, server, timeout = 100.millis)   // second call
+  *             -> inFlight = Some(id = 2, receiver = server)
+  *             -> state = waitForResponse again
+  *             -> envelope Req2 dispatched
+  *
+  * T+160ms   Resp1 (server's slow reply to Req1) finally arrives at channel
+  *             -> falls into the `case event =>` branch
+  *             -> withSender: sender == server
+  *             -> inFlight.receiver == server, match
+  *             -> completeAndReset(active = id = 2, castResponse(Resp1))
+  *             -> caller waiting on Req2 gets Resp1  // wrong reply
+  * }}}
   *
   * @tparam In
   *   events this channel is allowed to send.

--- a/parapet-core/src/main/scala/io/parapet/core/Channel.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Channel.scala
@@ -7,21 +7,36 @@ import io.parapet.effect.Monad.*
 import io.parapet.{Event, ProcessRef}
 
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import scala.concurrent.duration.FiniteDuration
+import scala.reflect.ClassTag
 import scala.util.Try
 
 /** A request/response helper process for synchronous-style interaction inside the asynchronous parapet runtime.
   *
   * A `Channel` is a small state machine: it accepts one [[Channel.Request]], forwards the embedded event to the target
-  * process, and completes the request's [[Deferred]] with the next event delivered back to it. While a request is in
-  * flight the channel rejects additional requests; this enforces a strict "one outstanding call" discipline.
+  * process, and completes the request's [[Deferred]] with the next response delivered back by that target. While a
+  * request is in flight the channel rejects additional requests; this enforces a strict "one outstanding call"
+  * discipline.
   *
-  * Callers typically construct a channel, register it under their own process, and use [[send]] to obtain a
-  * `Try[Event]` representing the eventual reply (or a transport failure).
+  * Callers typically construct a channel, register it under their own process, and use [[send]] to obtain a `Try[Out]`
+  * representing the eventual reply.
+  *
+  * `Channel` is intentionally not a reliable-delivery or correlated-RPC abstraction. It waits for the next response
+  * from the active receiver; if a timed-out receiver later replies while another request to the same receiver is in
+  * flight, the application protocol must distinguish that stale reply. TODO
+  *
+  * @tparam In
+  *   events this channel is allowed to send.
+  * @tparam Out
+  *   expected response event type.
   *
   * @param ref
   *   optional fixed reference; defaults to a fresh UUID.
   */
-class Channel[F[_]](override val ref: ProcessRef[Event] = ProcessRef.jdkUUIDRef[Event])(using Effect[F])
+class Channel[F[_], In <: Event, Out <: Event](
+    override val ref: ProcessRef[Event] = ProcessRef.jdkUUIDRef[Event]
+)(using Effect[F], ClassTag[Out])
     extends Process[F, Event, Event]:
   import Channel.*
   import dsl.*
@@ -29,86 +44,137 @@ class Channel[F[_]](override val ref: ProcessRef[Event] = ProcessRef.jdkUUIDRef[
   private val runtimeDsl = summon[Dsl.RuntimeOps.Aux[F]]
   import runtimeDsl.*
 
-  private var callback: Deferred[F, Try[Event]] = _
-  private val debugCallNumber                   = new AtomicInteger()
-  private val debugMode                         = false
+  private var inFlight: Option[InFlight[F, Out]] = None
+  private val debugCallNumber                    = new AtomicInteger()
+  private val requestIds                         = new AtomicLong()
+  private val debugMode                          = false
 
-  private def waitForRequest: Receive = { case req: Request[F] =>
-    eval {
-      callback = req.callback
-    } ++ req.event ~> req.receiver.asInstanceOf[ProcessRef[Event]] ++ switch(waitForResponse)
+  private def waitForRequest: Receive = {
+    case req: Request[F, Out] @unchecked => sendReq(req)
+    case Timeout(_)                      => unit
   }
 
   private def waitForResponse: Receive = {
     case Start => unit
     case Stop  =>
       flow {
-        if callback != null then
-          suspend(
-            callback.complete(scala.util.Failure(ChannelInterruptedException("channel has been closed"))).map(_ => ())
-          )
-        else unit
+        inFlight match
+          case Some(active) =>
+            complete(active, scala.util.Failure(ChannelInterruptedException("channel has been closed")))
+          case None => unit
       }
-    case req: Request[F] =>
+    case req: Request[F, Out] @unchecked =>
       suspend(
-        req.callback
+        req.result
           .complete(scala.util.Failure(IllegalChannelStateException("the current request is not completed yet")))
           .map(_ => ())
       )
+    case Timeout(id) =>
+      inFlight match
+        case Some(active) if active.id == id =>
+          active.timeout.fold(unit)(timeout =>
+            completeAndReset(active, scala.util.Failure(ChannelTimeoutException(timeout)))
+          )
+        case _ => unit
     case Failure(_, error) =>
-      suspend(callback.complete(scala.util.Failure(error)).map(_ => ())) ++ resetAndWaitForRequest
+      inFlight match
+        case Some(active) => completeAndReset(active, scala.util.Failure(error))
+        case None         => unit
     case event =>
-      suspend(callback.complete(scala.util.Success(event)).map(_ => ())) ++ debug(
-        s"resetAndWaitForRequest, event: $event"
-      ) ++ resetAndWaitForRequest
+      withSender { sender =>
+        inFlight match
+          case Some(active) if active.receiver == sender =>
+            debug(
+              s"resetAndWaitForRequest, event: $event"
+            ) ++ completeAndReset(active, castResponse(event))
+          case Some(active) =>
+            completeAndReset(
+              active,
+              scala.util.Failure(
+                UnexpectedChannelResponseException(
+                  s"expected response from ${active.receiver}, but received $event from $sender"
+                )
+              )
+            )
+          case None => unit
+      }
   }
 
   private def resetAndWaitForRequest: DslF[F, Unit] =
     eval {
-      callback = null
+      inFlight = None
     } ++ switch(waitForRequest)
 
-  def handle: Receive =
-    waitForRequest
-
-  /** @deprecated use the version without a callback. */
-  @deprecated("use the version without a callback")
-  def send[A, E <: Event](
-      event: E,
-      receiver: ProcessRef[? >: E],
-      callback: Try[Event] => DslF[F, A]
-  ): DslF[F, A] =
-    for
-      deferred <- suspend(Deferred[F, Try[Event]]())
-      _        <- Request(event, deferred, receiver) ~> ref
-      result   <- suspend(deferred.get)
-      value    <- callback(result)
-    yield value
+  def handle: Receive = waitForRequest
 
   /** Sends `event` to `receiver` and suspends until a response (or failure) arrives.
     *
-    * The implementation acquires the channel's runtime delivery lock for the duration of the call so concurrent senders
-    * queue cleanly.
+    * The implementation acquires the channel's runtime delivery lock while installing the request. If another request
+    * is already in flight, this call completes with [[IllegalChannelStateException]].
     *
     * @return
-    *   `Success(reply)` on a normal response, `Failure(throwable)` on transport error, channel closure, or remote
-    *   handler failure.
+    *   `Success(reply)` on a normal response, `Failure(error)` on error.
     */
-  def send[E <: Event](event: E, receiver: ProcessRef[? >: E]): DslF[F, Try[Event]] =
+  def send[E <: In](event: E, receiver: ProcessRef[? >: E]): DslF[F, Try[Out]] =
+    send(event, receiver, None)
+
+  /** Sends `event` to `receiver` and waits up to `timeout` for a response.
+    *
+    * If the timeout elapses before a response or failure arrives, the call completes with [[ChannelTimeoutException]]
+    * and the channel is reset for the next request.
+    */
+  def send[E <: In](event: E, receiver: ProcessRef[? >: E], timeout: FiniteDuration): DslF[F, Try[Out]] =
+    send(event, receiver, Some(timeout))
+
+  private def send[E <: In](
+      event: E,
+      receiver: ProcessRef[? >: E],
+      timeout: Option[FiniteDuration]
+  ): DslF[F, Try[Out]] =
     for
-      _        <- lockProcess(ref)
-      deferred <- suspend(Deferred[F, Try[Event]]())
-      _        <- sendReq(Request(event, deferred, receiver))
-      _        <- unlockProcess(ref)
-      value    <- suspend(deferred.get)
+      requestId <- eval(requestIds.incrementAndGet())
+      deferred  <- suspend(Deferred[F, Try[Out]]())
+      request = Request(requestId, event, deferred, receiver, timeout)
+      _     <- lockProcess(ref)
+      _     <- sendReq(request).guarantee(unlockProcess(ref))
+      value <- suspend(deferred.get)
     yield value
 
-  private def sendReq(req: Request[F]): DslF[F, Unit] =
+  private def sendReq(req: Request[F, Out]): DslF[F, Unit] =
     eval {
-      require(req.callback != null)
-      callback = req.callback
-    } ++ debug("waitForResponse") ++ switch(waitForResponse) ++
-      dsl.send(ref, req.event, req.receiver.asInstanceOf[ProcessRef[Event]])
+      inFlight match
+        case Some(_) => false
+        case None    =>
+          inFlight = Some(InFlight(req.id, req.result, req.receiver, req.timeout))
+          true
+    }.flatMap {
+      case true =>
+        req.timeout.fold(unit)(timeout => fork(delay(timeout) ++ Timeout(req.id) ~> ref).void) ++
+          debug("waitForResponse") ++ switch(waitForResponse) ++
+          dsl.send(ref, req.event, req.receiver.asInstanceOf[ProcessRef[Event]])
+      case false =>
+        suspend(
+          req.result
+            .complete(scala.util.Failure(IllegalChannelStateException("the current request is not completed yet")))
+            .map(_ => ())
+        )
+    }
+
+  private def castResponse(event: Event): Try[Out] =
+    event match
+      case out: Out => scala.util.Success(out)
+      case other    =>
+        scala.util.Failure(
+          UnexpectedChannelResponseException(
+            s"expected response matching ${summon[ClassTag[Out]]}, but received ${other.getClass.getName}: $other"
+          )
+        )
+
+  private def complete(active: InFlight[F, Out], result: Try[Out]): DslF[F, Unit] =
+    suspend(active.result.complete(result).map(_ => ()))
+
+  private def completeAndReset(active: InFlight[F, Out], result: Try[Out]): DslF[F, Unit] =
+    resetAndWaitForRequest ++ complete(active, result)
 
   private def debug(message: => String): DslF[F, Unit] =
     if debugMode then
@@ -131,14 +197,47 @@ object Channel:
   final case class IllegalChannelStateException(message: String, cause: Throwable = null)
       extends ChannelException(message, cause)
 
+  /** Raised when a request waits longer than the configured timeout. */
+  final case class ChannelTimeoutException(timeout: FiniteDuration, cause: Throwable = null)
+      extends ChannelException(s"channel request timed out after $timeout", cause)
+
+  /** Raised when the channel receives an event that cannot satisfy the expected reply contract. */
+  final case class UnexpectedChannelResponseException(message: String, cause: Throwable = null)
+      extends ChannelException(message, cause)
+
   /** Builds a fresh [[Channel]] with a UUID ref. */
-  def apply[F[_]](using Effect[F]): Channel[F] =
-    new Channel()
+  def apply[F[_]](using Effect[F]): Channel[F, Event, Event] =
+    new Channel[F, Event, Event]()
+
+  /** Builds a fresh typed [[Channel]] with a UUID ref. */
+  def apply[F[_], In <: Event, Out <: Event](using Effect[F], ClassTag[Out]): Channel[F, In, Out] =
+    new Channel[F, In, Out]()
 
   /** Builds a [[Channel]] pinned to `ref`. */
-  def apply[F[_]](ref: ProcessRef[Event])(using Effect[F]): Channel[F] =
-    new Channel(ref)
+  def apply[F[_]](ref: ProcessRef[Event])(using Effect[F]): Channel[F, Event, Event] =
+    new Channel[F, Event, Event](ref)
+
+  /** Builds a typed [[Channel]] pinned to `ref`. */
+  def apply[F[_], In <: Event, Out <: Event](ref: ProcessRef[Event])(using
+      Effect[F],
+      ClassTag[Out]
+  ): Channel[F, In, Out] =
+    new Channel[F, In, Out](ref)
 
   /** Internal request envelope sent from [[Channel.send]] to the channel's mailbox. */
-  final private case class Request[F[_]](event: Event, callback: Deferred[F, Try[Event]], receiver: ProcessRef.Unknown)
-      extends Event
+  final private case class Request[F[_], Out <: Event](
+      id: Long,
+      event: Event,
+      result: Deferred[F, Try[Out]],
+      receiver: ProcessRef.Unknown,
+      timeout: Option[FiniteDuration]
+  ) extends Event
+
+  final private case class InFlight[F[_], Out <: Event](
+      id: Long,
+      result: Deferred[F, Try[Out]],
+      receiver: ProcessRef.Unknown,
+      timeout: Option[FiniteDuration]
+  )
+
+  final private case class Timeout(id: Long) extends Event

--- a/parapet-core/src/main/scala/io/parapet/core/Channel.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Channel.scala
@@ -22,8 +22,8 @@ import scala.util.Try
   * representing the eventual reply.
   *
   * `Channel` is not a correlated-RPC abstraction: replies are matched only by the active receiver's ref, not by a
-  * per-request id. Without a correlation id, a late reply from the same receiver cannot be distinguished from the
-  * reply to the current in-flight request, so a stale reply can complete the wrong caller. Example:
+  * per-request id. Without a correlation id, a late reply from the same receiver cannot be distinguished from the reply
+  * to the current in-flight request, so a stale reply can complete the wrong caller. Example:
   *
   * {{{
   * T+0ms     channel.send(Req1, server, timeout = 100.millis)

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/ParIOSpecs.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/ParIOSpecs.scala
@@ -7,7 +7,7 @@ import io.parapet.core.Events
 import io.parapet.core.Events.Start
 import io.parapet.core.Process
 import io.parapet.core.{Channel, Parapet}
-import io.parapet.core.Channel.ChannelInterruptedException
+import io.parapet.core.Channel.ChannelTimeoutException
 import io.parapet.core.Parapet.ParConfig
 import io.parapet.core.Scheduler.SchedulerConfig
 import io.parapet.effect.ParIO
@@ -103,24 +103,17 @@ class BlockingChannelWithTimeout extends AnyFunSuite with BasicParIOSpec:
       .build
 
     val clientRef = ProcessRef("client")
-    val ch        = new Channel[ParIO](clientRef)
+    val ch        = new Channel[ParIO, ByteEvent, ByteEvent](clientRef)
     val client    = Process
       .builder[ParIO](ref => { case Start =>
         register(ref, ch) ++
           blocking {
-            race(
-              ch.send(
-                ByteEvent("request".getBytes()),
-                server.ref,
-                {
-                  case scala.util.Failure(ChannelInterruptedException(_, _)) =>
-                    eval(println("channel was interrupted")) ++ ByteEvent("help".getBytes()) ~> failover
-                  case res =>
-                    eval(println(s"client received: $res"))
-                }
-              ),
-              delay(3.seconds) ++ eval(println("server doesn't respond"))
-            ) ++ ch.send(ByteEvent("request".getBytes()), failover.ref, _ => unit)
+            ch.send(ByteEvent("request".getBytes()), server.ref, 3.seconds).flatMap {
+              case scala.util.Failure(ChannelTimeoutException(_, _)) =>
+                eval(println("channel timed out")) ++ ByteEvent("help".getBytes()) ~> failover
+              case res =>
+                eval(println(s"client received: $res"))
+            } ++ ch.send(ByteEvent("request".getBytes()), failover.ref).void
           }
       })
       .ref(clientRef)

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
@@ -7,6 +7,7 @@ import io.parapet.core.Scheduler.SchedulerConfig
 import io.parapet.core.exceptions.EventHandlingException
 import io.parapet.core.{Channel, Process}
 import io.parapet.core.Channel.{
+  ChannelInterruptedException,
   ChannelTimeoutException,
   IllegalChannelStateException,
   UnexpectedChannelResponseException
@@ -306,6 +307,38 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
     eventStore.get(client.ref) shouldBe Seq(WrongSender)
   }
 
+  test("channel surfaces interruption when stopped while a request is in flight") {
+    val eventStore = new EventStore[F, Event]
+    val clientRef  = ProcessRef("client")
+
+    val ch = Channel[F, Request, Response]
+
+    // Server stops the channel synchronously upon receiving the request, exercising the `case Stop` branch
+    // of `waitForResponse` while a request is in flight. The scheduler intercepts `Stop` on the channel's
+    // mailbox and runs the current handler synchronously via `deliverStopEvent`, so there is no timing race.
+    val server = new Process[F, Request, Nothing] {
+      override val ref: ProcessRef[Request] = ProcessRef("server")
+
+      override def handle: Receive = { case Request(_) =>
+        Stop ~> ch.ref // this sucks. but this is the good case to test.
+      }
+    }
+
+    val client = new Process[F, Event, Event] {
+      override val ref: ProcessRef[Event] = clientRef
+
+      override def handle: Receive = { case Start =>
+        register(ref, ch) ++ ch.send(Request(0), server.ref).flatMap {
+          case SFailure(_: ChannelInterruptedException) => eval(eventStore.add(ref, Interrupted))
+          case other                                    => eval(fail(s"expected interrupted, got $other"))
+        }
+      }
+    }
+
+    unsafeRun(eventStore.await(1, createApp(ct.pure(Seq(client, server))).run))
+    eventStore.get(client.ref) shouldBe Seq(Interrupted)
+  }
+
 }
 
 object ChannelSpec {
@@ -325,5 +358,7 @@ object ChannelSpec {
   case object ReceiverFailed extends Event
 
   case object WrongSender extends Event
+
+  case object Interrupted extends Event
 
 }

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
@@ -4,22 +4,27 @@ import io.parapet.core.Dsl.DslF
 import io.parapet.core.Events.{Start, Stop}
 import io.parapet.core.Parapet.ParConfig
 import io.parapet.core.Scheduler.SchedulerConfig
+import io.parapet.core.exceptions.EventHandlingException
 import io.parapet.core.{Channel, Process}
+import io.parapet.core.Channel.{
+  ChannelTimeoutException,
+  IllegalChannelStateException,
+  UnexpectedChannelResponseException
+}
 import io.parapet.tests.intg.ChannelSpec._
 import io.parapet.testutils.EventStore
 import io.parapet.{Event, ProcessRef}
-import org.scalatest.Ignore
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._
 
+import scala.concurrent.duration.*
 import scala.util.{Failure => SFailure, Success}
 
-@Ignore
 abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
 
   import dsl._
 
-  test("channel") {
+  test("channel can be reused for sequential request/reply dialogs") {
 
     val eventStore = new EventStore[F, Event]
 
@@ -39,17 +44,13 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
       override val ref  = ProcessRef("client")
       var seq           = 0
 
-      val ch = new Channel[F]()
+      val ch = new Channel[F, Request, Response]()
 
       def sendRequest(request: Request): DslF[F, Unit] =
-        ch.send(
-          request,
-          server.ref,
-          {
-            case SFailure(err) => eval(throw err)
-            case Success(res)  => eval(eventStore.add(ref, res))
-          }
-        )
+        ch.send(request, server.ref).flatMap {
+          case SFailure(err) => eval(throw err)
+          case Success(res)  => eval(eventStore.add(ref, res))
+        }
 
       override def handle: Receive = {
         case Start =>
@@ -76,7 +77,7 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
     val clientRef  = ProcessRef("client")
     val serverRef  = ProcessRef("server")
 
-    val ch = Channel[F]
+    val ch = Channel[F, Request, Response]
 
     val server = new Process[F, Event, Event] {
       override val ref: ProcessRef[Event] = serverRef
@@ -104,6 +105,207 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
     eventStore.get(client.ref) shouldBe Seq(Response(1))
   }
 
+  test("channel times out when the receiver does not reply") {
+    val eventStore = new EventStore[F, Event]
+    val clientRef  = ProcessRef("client")
+
+    val ch = Channel[F, Request, Response]
+
+    val server = new Process[F, Request, Nothing] {
+      override val ref: ProcessRef[Request] = ProcessRef("server")
+
+      override def handle: Receive = { case Request(_) =>
+        unit
+      }
+    }
+
+    val client = new Process[F, Event, Event] {
+      override val ref: ProcessRef[Event] = clientRef
+
+      override def handle: Receive = { case Start =>
+        register(ref, ch) ++ ch.send(Request(0), server.ref, 25.millis).flatMap {
+          case SFailure(ChannelTimeoutException(_, _)) => eval(eventStore.add(ref, TimedOut))
+          case other                                   => eval(fail(s"expected timeout, got $other"))
+        }
+      }
+    }
+
+    unsafeRun(eventStore.await(1, createApp(ct.pure(Seq(client, server))).run))
+    eventStore.get(client.ref) shouldBe Seq(TimedOut)
+  }
+
+  test("channel fails when the reply does not match the expected output type") {
+    val eventStore = new EventStore[F, Event]
+    val clientRef  = ProcessRef("client")
+
+    val ch = Channel[F, Request, Response]
+
+    val server = new Process[F, Request, WrongResponse.type] {
+      override val ref: ProcessRef[Request] = ProcessRef("server")
+
+      override def handle: Receive = { case Request(_) =>
+        reply(WrongResponse)
+      }
+    }
+
+    val client = new Process[F, Event, Event] {
+      override val ref: ProcessRef[Event] = clientRef
+
+      override def handle: Receive = { case Start =>
+        register(ref, ch) ++ ch.send(Request(0), server.ref).flatMap {
+          case SFailure(_: UnexpectedChannelResponseException) => eval(eventStore.add(ref, WrongReply))
+          case other => eval(fail(s"expected unexpected response, got $other"))
+        }
+      }
+    }
+
+    unsafeRun(eventStore.await(1, createApp(ct.pure(Seq(client, server))).run))
+    eventStore.get(client.ref) shouldBe Seq(WrongReply)
+  }
+
+  test("channel rejects a second request while one is in flight") {
+    val eventStore = new EventStore[F, Event]
+    val clientRef  = ProcessRef("client")
+
+    val ch = Channel[F, Request, Response]
+
+    val server = new Process[F, Request, Response] {
+      override val ref: ProcessRef[Request] = ProcessRef("server")
+
+      override def handle: Receive = { case Request(seq) =>
+        delay(250.millis) ++ reply(Response(seq))
+      }
+    }
+
+    val client = new Process[F, Event, Event] {
+      override val ref: ProcessRef[Event] = clientRef
+
+      override def handle: Receive = { case Start =>
+        register(ref, ch) ++
+          fork {
+            ch.send(Request(1), server.ref, 1.second).flatMap {
+              case Success(response) => eval(eventStore.add(ref, response))
+              case other             => eval(fail(s"expected first request to complete, got $other"))
+            }
+          }.void ++
+          delay(50.millis) ++
+          ch.send(Request(2), server.ref, 100.millis).flatMap {
+            case SFailure(_: IllegalChannelStateException) => eval(eventStore.add(ref, ConcurrentRejected))
+            case other => eval(fail(s"expected concurrent request rejection, got $other"))
+          }
+      }
+    }
+
+    unsafeRun(eventStore.await(2, createApp(ct.pure(Seq(client, server))).run, timeout = 5.seconds))
+    eventStore.get(client.ref).toSet shouldBe Set(Response(1), ConcurrentRejected)
+  }
+
+  test("channel can be reused after a timeout") {
+    val eventStore = new EventStore[F, Event]
+    val clientRef  = ProcessRef("client")
+
+    val ch = Channel[F, Request, Response]
+
+    val silent = new Process[F, Request, Nothing] {
+      override val ref: ProcessRef[Request] = ProcessRef("silent")
+
+      override def handle: Receive = { case Request(_) =>
+        unit
+      }
+    }
+
+    val server = new Process[F, Request, Response] {
+      override val ref: ProcessRef[Request] = ProcessRef("server")
+
+      override def handle: Receive = { case Request(seq) =>
+        reply(Response(seq))
+      }
+    }
+
+    val client = new Process[F, Event, Event] {
+      override val ref: ProcessRef[Event] = clientRef
+
+      override def handle: Receive = { case Start =>
+        register(ref, ch) ++
+          ch.send(Request(0), silent.ref, 25.millis).flatMap {
+            case SFailure(ChannelTimeoutException(_, _)) => eval(eventStore.add(ref, TimedOut))
+            case other                                   => eval(fail(s"expected timeout, got $other"))
+          } ++
+          ch.send(Request(2), server.ref).flatMap {
+            case Success(response) => eval(eventStore.add(ref, response))
+            case other             => eval(fail(s"expected reuse after timeout to complete, got $other"))
+          }
+      }
+    }
+
+    unsafeRun(eventStore.await(2, createApp(ct.pure(Seq(client, silent, server))).run, timeout = 5.seconds))
+    eventStore.get(client.ref) shouldBe Seq(TimedOut, Response(2))
+  }
+
+  test("channel returns receiver handler failures") {
+    val eventStore = new EventStore[F, Event]
+    val clientRef  = ProcessRef("client")
+
+    val ch = Channel[F, Request, Response]
+
+    val server = new Process[F, Request, Nothing] {
+      override val ref: ProcessRef[Request] = ProcessRef("server")
+
+      override def handle: Receive = { case Request(_) =>
+        eval(throw new RuntimeException("505"))
+      }
+    }
+
+    val client = new Process[F, Event, Event] {
+      override val ref: ProcessRef[Event] = clientRef
+
+      override def handle: Receive = { case Start =>
+        register(ref, ch) ++ ch.send(Request(0), server.ref).flatMap {
+          case SFailure(EventHandlingException(_, cause)) if cause.getMessage == "505" =>
+            eval(eventStore.add(ref, ReceiverFailed))
+          case other => eval(fail(s"expected receiver failure, got $other"))
+        }
+      }
+    }
+
+    unsafeRun(eventStore.await(1, createApp(ct.pure(Seq(client, server))).run))
+    eventStore.get(client.ref) shouldBe Seq(ReceiverFailed)
+  }
+
+  test("channel rejects a response from a process other than the active receiver") {
+    val eventStore = new EventStore[F, Event]
+    val clientRef  = ProcessRef("client")
+
+    val ch = Channel[F, Request, Response]
+
+    val server = new Process[F, Request, Nothing] {
+      override val ref: ProcessRef[Request] = ProcessRef("server")
+
+      override def handle: Receive = { case Request(_) =>
+        unit
+      }
+    }
+
+    val client = new Process[F, Event, Event] {
+      override val ref: ProcessRef[Event] = clientRef
+
+      override def handle: Receive = { case Start =>
+        register(ref, ch) ++
+          fork {
+            ch.send(Request(1), server.ref, 1.second).flatMap {
+              case SFailure(_: UnexpectedChannelResponseException) => eval(eventStore.add(ref, WrongSender))
+              case other => eval(fail(s"expected wrong sender rejection, got $other"))
+            }
+          }.void ++
+          delay(50.millis) ++
+          Response(99) ~> ch.ref
+      }
+    }
+
+    unsafeRun(eventStore.await(1, createApp(ct.pure(Seq(client, server))).run, timeout = 5.seconds))
+    eventStore.get(client.ref) shouldBe Seq(WrongSender)
+  }
+
 }
 
 object ChannelSpec {
@@ -111,5 +313,17 @@ object ChannelSpec {
   case class Request(seq: Int) extends Event
 
   case class Response(seq: Int) extends Event
+
+  case object WrongResponse extends Event
+
+  case object TimedOut extends Event
+
+  case object WrongReply extends Event
+
+  case object ConcurrentRejected extends Event
+
+  case object ReceiverFailed extends Event
+
+  case object WrongSender extends Event
 
 }

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/SwitchBehaviorSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/SwitchBehaviorSpec.scala
@@ -31,11 +31,11 @@ abstract class SwitchBehaviorSpec[F[_]] extends AnyFunSuite with IntegrationSpec
     val p2 = new TestProcess[F](saveEvent2(p2Ref), eventStore, p2Ref)
 
     val p  = p1.or(p2)
-    val ch = new Channel[F]()
+    val ch = new Channel[F, Switch, Event]()
 
     val test = onStart {
       // we need a channel here to introduce synchronization boundary, this approach can be improved in future releases
-      register(TestSystemRef, ch) ++ ch.send(Switch(State3), p2.ref, _ => Event3 ~> p)
+      register(TestSystemRef, ch) ++ ch.send(Switch(State3), p2.ref).flatMap(_ => Event3 ~> p)
     }
 
     unsafeRun(eventStore.await(1, createApp(ct.pure(Seq(test, p, p2))).run))


### PR DESCRIPTION
This PR adds typed request/reply semantics to Channel: Channel[F, In, Out], so callers declare the event they send and the response type they expect. Adds timeout support, single in-flight request enforcement, typed response validation, and clearer channel-specific failures. Updates ChannelSpec to cover sequential reuse, concurrent rejection, timeout/reuse, wrong reply type, wrong sender, and receiver failure propagation. This keeps Channel as a synchronous request/reply helper, not a reliable-delivery abstraction.

There is still an open issue that needs a fix: 

```
T+0ms     channel.send(Req1, server, timeout=100ms)
            -> inFlight = Some(id=1, receiver=server)
            -> state = waitForResponse
            -> envelope Req1 dispatched to server
            -> fork(delay(100ms) ++ Timeout(1) ~> channel)

T+100ms   Timeout(1) arrives at channel
            line 72-78: active.id == 1 -> match
            -> caller's Deferred completes with ChannelTimeoutException
            -> resetAndWaitForRequest (line 103) clears inFlight, switches to waitForRequest

T+150ms   channel.send(Req2, server, timeout=100ms)   // a second call
            -> inFlight = Some(id=2, receiver=server)
            -> state = waitForResponse again
            -> envelope Req2 dispatched

T+160ms   Resp1 (server's slow reply to Req1) finally arrives at channel
            -> falls into the `case event =>` branch on line 83
            -> withSender: sender == server
            -> inFlight.receiver == server  ← match (line 86)
            -> channel calls completeAndReset(active=id=2, castResponse(Resp1))
            -> caller waiting on Req2 gets Resp1
            -> 💥
```

that issue will be address in a separate PR