### PR TITLE
Add `Scope` metadata; fix `Channel` stale-reply bug

### DIFF
--- a/parapet-core/src/main/scala/io/parapet/Envelope.scala
+++ b/parapet-core/src/main/scala/io/parapet/Envelope.scala
@@ -2,17 +2,21 @@ package io.parapet
 
 /** A delivery wrapper that pairs an [[Event]] with its routing metadata.
   *
-  * The runtime never moves bare events between processes; it always wraps them in an `Envelope` so that the receiver
-  * can identify the sender (e.g., to reply) and the scheduler can dispatch to the correct mailbox.
-  *
   * @param sender
   *   the originating process; may be [[ProcessRef.UndefinedRef]] for events produced by the runtime itself.
   * @param event
   *   the payload being delivered.
   * @param receiver
-  *   the addressed process; the scheduler routes this envelope to the mailbox identified by this ref.
+  *   the addressed process.
+  * @param scope
+  *   metadata attached to this delivery; defaults to [[Scope.empty]].
   */
-final case class Envelope(sender: ProcessRef.Unknown, event: Event, receiver: ProcessRef.Unknown):
+final case class Envelope(
+    sender: ProcessRef.Unknown,
+    event: Event,
+    receiver: ProcessRef.Unknown,
+    scope: Scope = Scope.empty
+):
   self =>
 
   /** Reserved for future tracing/debugging support; currently always `0`. */
@@ -21,11 +25,12 @@ final case class Envelope(sender: ProcessRef.Unknown, event: Event, receiver: Pr
   /** Reserved for future tracing/debugging support; currently always empty. */
   val id: String = ""
 
-  /** Returns a copy of this envelope with [[event]] replaced by `value`. The sender and receiver are preserved - handy
-    * for [[io.parapet.core.EventTransformer]] stages.
+  /** Returns a copy of this envelope with [[event]] replaced by `value`. The sender, receiver, and scope are preserved -
+    * handy for [[io.parapet.core.EventTransformer]] stages.
     */
   def event(value: Event): Envelope =
     self.copy(event = value)
 
   override def toString: String =
-    s"Envelope(id:$id, sender:$sender, event:$event, receiver:$receiver, ts:$ts)"
+    if scope.isEmpty then s"Envelope(id:$id, sender:$sender, event:$event, receiver:$receiver, ts:$ts)"
+    else s"Envelope(id:$id, sender:$sender, event:$event, receiver:$receiver, ts:$ts, scope:${scope.entries.toMap})"

--- a/parapet-core/src/main/scala/io/parapet/Scope.scala
+++ b/parapet-core/src/main/scala/io/parapet/Scope.scala
@@ -1,11 +1,6 @@
 package io.parapet
 
-/** A typed metadata.
-  *
-  * Each entry is identified by a [[Scope.Key]] which fixes the value type at compile time, so reading an entry returns
-  * the exact type the writer put in. `Scope` is an immutable, persistent map; [[Scope.put]] returns a new value sharing
-  * structure with the original.
-  */
+/** Immutable typed metadata. */
 opaque type Scope = Map[String, Any]
 
 object Scope:
@@ -22,7 +17,8 @@ object Scope:
     /** Globally unique identifier; serves as the underlying map key. */
     def name: String
 
-  /** Identifier of a request that a subsequent message is the response to. */
+  /** Identifier of the operation/message that caused a subsequent message.
+    */
   case object Causation extends Key[String]:
     val name: String = "io.parapet.causation"
 

--- a/parapet-core/src/main/scala/io/parapet/Scope.scala
+++ b/parapet-core/src/main/scala/io/parapet/Scope.scala
@@ -1,0 +1,48 @@
+package io.parapet
+
+/** A typed metadata.
+  *
+  * Each entry is identified by a [[Scope.Key]] which fixes the value type at compile time, so reading an entry returns
+  * the exact type the writer put in. `Scope` is an immutable, persistent map; [[Scope.put]] returns a new value sharing
+  * structure with the original.
+  */
+opaque type Scope = Map[String, Any]
+
+object Scope:
+
+  /** The scope with no entries. */
+  val empty: Scope = Map.empty
+
+  /** Typed key for a scope entry.
+    *
+    * @tparam A
+    *   the value type associated with this key.
+    */
+  trait Key[A]:
+    /** Globally unique identifier; serves as the underlying map key. */
+    def name: String
+
+  /** Identifier of a request that a subsequent message is the response to. */
+  case object Causation extends Key[String]:
+    val name: String = "io.parapet.causation"
+
+  extension (scope: Scope)
+    /** Value associated with `key`, or `None` if absent. */
+    def get[A](key: Key[A]): Option[A] =
+      scope.get(key.name).asInstanceOf[Option[A]]
+
+    /** A new scope with `key -> value` added or replaced. */
+    def put[A](key: Key[A], value: A): Scope =
+      scope.updated(key.name, value)
+
+    /** A new scope without `key`. */
+    def remove(key: Key[?]): Scope =
+      scope - key.name
+
+    /** True when this scope has no entries. */
+    def isEmpty: Boolean =
+      scope.isEmpty
+
+    /** Underlying name->value pairs. */
+    def entries: Iterable[(String, Any)] =
+      scope

--- a/parapet-core/src/main/scala/io/parapet/core/Channel.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Channel.scala
@@ -4,7 +4,7 @@ import io.parapet.core.Dsl.DslF
 import io.parapet.core.Events.{Failure, Start, Stop}
 import io.parapet.effect.{Deferred, Effect}
 import io.parapet.effect.Monad.*
-import io.parapet.{Event, ProcessRef}
+import io.parapet.{Event, ProcessRef, Scope}
 
 import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.duration.FiniteDuration
@@ -21,34 +21,7 @@ import scala.util.Try
   * Callers typically construct a channel, register it under their own process, and use [[send]] to obtain a `Try[Out]`
   * representing the eventual reply.
   *
-  * `Channel` is not a correlated-RPC abstraction: replies are matched only by the active receiver's ref, not by a
-  * per-request id. Without a correlation id, a late reply from the same receiver cannot be distinguished from the reply
-  * to the current in-flight request, so a stale reply can complete the wrong caller. Example:
-  *
-  * {{{
-  * T+0ms     channel.send(Req1, server, timeout = 100.millis)
-  *             -> inFlight = Some(id = 1, receiver = server)
-  *             -> state = waitForResponse
-  *             -> envelope Req1 dispatched to server
-  *             -> fork(delay(100.millis) ++ Timeout(1) ~> channel)
-  *
-  * T+100ms   Timeout(1) arrives at channel
-  *             -> active.id == 1, match
-  *             -> caller's Deferred completes with ChannelTimeoutException
-  *             -> resetAndWaitForRequest clears inFlight, switches to waitForRequest
-  *
-  * T+150ms   channel.send(Req2, server, timeout = 100.millis)   // second call
-  *             -> inFlight = Some(id = 2, receiver = server)
-  *             -> state = waitForResponse again
-  *             -> envelope Req2 dispatched
-  *
-  * T+160ms   Resp1 (server's slow reply to Req1) finally arrives at channel
-  *             -> falls into the `case event =>` branch
-  *             -> withSender: sender == server
-  *             -> inFlight.receiver == server, match
-  *             -> completeAndReset(active = id = 2, castResponse(Resp1))
-  *             -> caller waiting on Req2 gets Resp1  // wrong reply
-  * }}}
+  * Replies are correlated to in-flight requests by [[Scope.Causation]].
   *
   * @tparam In
   *   events this channel is allowed to send.
@@ -108,19 +81,29 @@ class Channel[F[_], In <: Event, Out <: Event](
         case None         => unit
     case event =>
       withSender { sender =>
-        inFlight match
-          case Some(active) if active.receiver == sender =>
-            completeAndReset(active, castResponse(event))
-          case Some(active) =>
-            completeAndReset(
-              active,
-              scala.util.Failure(
-                UnexpectedChannelResponseException(
-                  s"expected response from ${active.receiver}, but received $event from $sender"
+        withScope { scope =>
+          inFlight match
+            case Some(active) =>
+              val incomingCausation = scope.get(Scope.Causation)
+              if incomingCausation.contains(active.causationId) then
+                // Correlated reply for the in-flight request.
+                completeAndReset(active, castResponse(event))
+              else if active.receiver != sender then
+                // Wrong sender (an unrelated process sent something).
+                completeAndReset(
+                  active,
+                  scala.util.Failure(
+                    UnexpectedChannelResponseException(
+                      s"expected response from ${active.receiver}, but received $event from $sender"
+                    )
+                  )
                 )
-              )
-            )
-          case None => unit
+              else
+                // Active receiver, but causation does not match: stale reply from a prior (timed-out) request.
+                // Silently drop; the original caller has already received a ChannelTimeoutException.
+                unit
+            case None => unit
+        }
       }
   }
 
@@ -169,13 +152,18 @@ class Channel[F[_], In <: Event, Out <: Event](
       inFlight match
         case Some(_) => false
         case None    =>
-          inFlight = Some(InFlight(req.id, req.result, req.receiver, req.timeout))
+          inFlight = Some(InFlight(req.id, causationIdOf(req.id), req.result, req.receiver, req.timeout))
           true
     }.flatMap {
       case true =>
+        val causationId = causationIdOf(req.id)
         req.timeout.fold(unit)(timeout => fork(delay(timeout) ++ Timeout(req.id) ~> ref).void) ++
           switch(waitForResponse) ++
-          dsl.send(ref, req.event, req.receiver.asInstanceOf[ProcessRef[Event]])
+          // Stamp the outbound request envelope with this request's causation id; the receiver's reply will carry
+          // the same id back via scope auto-propagation, letting waitForResponse correlate it to `inFlight`.
+          mapScope(_.put(Scope.Causation, causationId)) {
+            dsl.send(ref, req.event, req.receiver.asInstanceOf[ProcessRef[Event]])
+          }
       case false =>
         suspend(
           req.result
@@ -183,6 +171,9 @@ class Channel[F[_], In <: Event, Out <: Event](
             .map(_ => ())
         )
     }
+
+  private def causationIdOf(id: Long): String =
+    s"${ref.value}:$id"
 
   private def castResponse(event: Event): Try[Out] =
     event match
@@ -251,6 +242,7 @@ object Channel:
 
   final private case class InFlight[F[_], Out <: Event](
       id: Long,
+      causationId: String,
       result: Deferred[F, Try[Out]],
       receiver: ProcessRef.Unknown,
       timeout: Option[FiniteDuration]

--- a/parapet-core/src/main/scala/io/parapet/core/Dsl.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Dsl.scala
@@ -2,7 +2,7 @@ package io.parapet.core
 
 import io.parapet.core.annotations.developerApi
 import io.parapet.free.{Free, Inject}
-import io.parapet.{Event, ProcessRef}
+import io.parapet.{Event, ProcessRef, Scope}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -113,6 +113,16 @@ object Dsl:
 
   /** Releases a previously acquired [[Lock]]. */
   final case class Unlock[F[_]](ref: ProcessRef.Unknown) extends FlowOp[F, Unit]
+
+  /** Provides the interpreter's current [[io.parapet.Scope]] to `f`, which builds the next program step from it.
+    * Read-only; the scope itself is not mutated by this op.
+    */
+  final case class WithScope[F[_], G[_], A](f: Scope => Free[G, A]) extends FlowOp[F, A]
+
+  /** Runs `body` with the current scope transformed by `f`. The outer scope is restored as soon as `body` completes
+    * (success or failure), so `mapScope` is a lexical, local override that never leaks past its block.
+    */
+  final case class MapScope[F[_], G[_], A](f: Scope => Scope, body: Free[G, A]) extends FlowOp[F, A]
 
   /** Smart constructors for the [[FlowOp]] algebra.
     *
@@ -315,6 +325,18 @@ object Dsl:
               acc.flatMap(_ => send(event, sender))
             }
       }
+
+    /** Reads the current [[Scope]] and builds the next step from it. */
+    @developerApi
+    private[core] def withScope[A](f: Scope => Free[C, A]): Free[C, A] =
+      Free.inject[[x] =>> FlowOp[F, x], C, A](WithScope[F, C, A](f))
+
+    /** Runs `body` under the scope produced by `f(currentScope)`. The transformation is lexical: once `body` finishes
+      * (whether by success or by raising), the outer scope is restored for the rest of the program.
+      */
+    @developerApi
+    private[core] def mapScope[A](f: Scope => Scope)(body: Free[C, A]): Free[C, A] =
+      Free.inject[[x] =>> FlowOp[F, x], C, A](MapScope[F, C, A](f, body))
 
     /** Executes `flow` asynchronously as a [[Fiber]]. The fiber runs concurrently and the returned handle can be
       * awaited via [[Fiber.join]] or cancelled.

--- a/parapet-core/src/main/scala/io/parapet/core/Dsl.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Dsl.scala
@@ -114,13 +114,20 @@ object Dsl:
   /** Releases a previously acquired [[Lock]]. */
   final case class Unlock[F[_]](ref: ProcessRef.Unknown) extends FlowOp[F, Unit]
 
-  /** Provides the interpreter's current [[io.parapet.Scope]] to `f`, which builds the next program step from it.
-    * Read-only; the scope itself is not mutated by this op.
+  /** Reads the interpreter's current [[io.parapet.Scope]].
+    *
+    * The current scope is reader-context metadata, normally copied from the incoming [[io.parapet.Envelope]]. Reading
+    * it does not mutate anything. The continuation `f` builds the next program step after seeing the scope, and that
+    * next step continues under the same scope.
     */
   final case class WithScope[F[_], G[_], A](f: Scope => Free[G, A]) extends FlowOp[F, A]
 
-  /** Runs `body` with the current scope transformed by `f`. The outer scope is restored as soon as `body` completes
-    * (success or failure), so `mapScope` is a lexical, local override that never leaks past its block.
+  /** Runs `body` under a transformed scope.
+    *
+    * The interpreter evaluates `f(currentScope)` once when entering the block, then interprets `body` with that derived
+    * scope. Every outbound envelope emitted by `body` carries the derived scope. When `body` completes, the outer scope
+    * is restored for the rest of the program, so this is a lexical override rather than a mutation of global/runtime
+    * state.
     */
   final case class MapScope[F[_], G[_], A](f: Scope => Scope, body: Free[G, A]) extends FlowOp[F, A]
 
@@ -331,8 +338,10 @@ object Dsl:
     private[core] def withScope[A](f: Scope => Free[C, A]): Free[C, A] =
       Free.inject[[x] =>> FlowOp[F, x], C, A](WithScope[F, C, A](f))
 
-    /** Runs `body` under the scope produced by `f(currentScope)`. The transformation is lexical: once `body` finishes
-      * (whether by success or by raising), the outer scope is restored for the rest of the program.
+    /** Runs `body` under the scope produced by `f(currentScope)`.
+      *
+      * The transformation is lexical: outbound envelopes created inside `body` carry the derived scope, but once `body`
+      * finishes (whether by success or by raising), subsequent operations continue with the outer scope.
       */
     @developerApi
     private[core] def mapScope[A](f: Scope => Scope)(body: Free[C, A]): Free[C, A] =

--- a/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -14,16 +14,20 @@ import io.parapet.{Envelope, Event, ProcessRef, Scope}
   * mapped to an `F`-effect and all routing/scheduling work goes through the surrounding [[Context]] and [[Scheduler]].
   *
   * Custom interpreters can be plugged in via [[io.parapet.ParApp.interpreter]] for cases such as tracing or recording.
+  *
+  * The interpreter also carries an immutable [[Scope]] reader context. The scheduler seeds that context from the
+  * incoming envelope, `Send` / `Forward` stamp it onto outbound envelopes, [[WithScope]] reads it, and [[MapScope]]
+  * interprets a nested program under a derived scope.
   */
 object DslInterpreter:
   /** A natural transformation from `FlowOp[F, *]` to `F[*]`. Several overloads adapt the call-site to whatever target
     * identification is convenient (raw ref vs. resolved [[ProcessState]]).
     */
   trait Interpreter[F[_]]:
-    /** Interprets ops in the context of `target`, allocating a fresh trace and empty scope. */
+    /** Interprets ops in the context of `target`, allocating a fresh trace and starting from [[Scope.empty]]. */
     def interpret(sender: ProcessRef.Unknown, target: ProcessRef.Unknown): ([x] =>> FlowOp[F, x]) ~> F
 
-    /** Interprets ops in the context of `target` reusing `execTrace` for causal id. */
+    /** Interprets ops in the context of `target`, reusing `execTrace` and starting from [[Scope.empty]]. */
     def interpret(
         sender: ProcessRef.Unknown,
         target: ProcessRef.Unknown,

--- a/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -6,7 +6,7 @@ import io.parapet.core.Scheduler.{Deliver, ProcessQueueIsFull}
 import io.parapet.effect.{Deferred, Effect}
 import io.parapet.effect.Monad.*
 import io.parapet.free.{FunctionK, ~>}
-import io.parapet.{Envelope, Event, ProcessRef}
+import io.parapet.{Envelope, Event, ProcessRef, Scope}
 
 /** Translates parapet [[Dsl.FlowOp]] programs into the user's effect type `F[_]`.
   *
@@ -16,11 +16,11 @@ import io.parapet.{Envelope, Event, ProcessRef}
   * Custom interpreters can be plugged in via [[io.parapet.ParApp.interpreter]] for cases such as tracing or recording.
   */
 object DslInterpreter:
-  /** A natural transformation from `FlowOp[F, *]` to `F[*]`. Three overloads adapt the call-site to whatever target
+  /** A natural transformation from `FlowOp[F, *]` to `F[*]`. Several overloads adapt the call-site to whatever target
     * identification is convenient (raw ref vs. resolved [[ProcessState]]).
     */
   trait Interpreter[F[_]]:
-    /** Interprets ops in the context of `target`, allocating a fresh trace. */
+    /** Interprets ops in the context of `target`, allocating a fresh trace and empty scope. */
     def interpret(sender: ProcessRef.Unknown, target: ProcessRef.Unknown): ([x] =>> FlowOp[F, x]) ~> F
 
     /** Interprets ops in the context of `target` reusing `execTrace` for causal id. */
@@ -30,13 +30,19 @@ object DslInterpreter:
         execTrace: ExecutionTrace
     ): ([x] =>> FlowOp[F, x]) ~> F
 
-    /** Interprets ops directly against a known [[ProcessState]] - the form used by the scheduler hot path so it can
-      * avoid an extra registry lookup.
-      */
+    /** Interprets ops directly against a known [[ProcessState]] with an empty scope. */
     def interpret(
         sender: ProcessRef.Unknown,
         processState: ProcessState[F],
         execTrace: ExecutionTrace
+    ): ([x] =>> FlowOp[F, x]) ~> F
+
+    /** Interprets ops against a known [[ProcessState]] starting from `scope`. */
+    def interpret(
+        sender: ProcessRef.Unknown,
+        processState: ProcessState[F],
+        execTrace: ExecutionTrace,
+        scope: Scope
     ): ([x] =>> FlowOp[F, x]) ~> F
 
   /** Builds the default [[Impl]] interpreter bound to `context`. */
@@ -55,12 +61,20 @@ object DslInterpreter:
         target: ProcessRef.Unknown,
         execTrace: ExecutionTrace
     ): ([x] =>> FlowOp[F, x]) ~> F =
-      interpret(sender, context.getProcessState(target).get, execTrace)
+      interpret(sender, context.getProcessState(target).get, execTrace, Scope.empty)
 
     def interpret(
         sender: ProcessRef.Unknown,
         processState: ProcessState[F],
         execTrace: ExecutionTrace
+    ): ([x] =>> FlowOp[F, x]) ~> F =
+      interpret(sender, processState, execTrace, Scope.empty)
+
+    def interpret(
+        sender: ProcessRef.Unknown,
+        processState: ProcessState[F],
+        execTrace: ExecutionTrace,
+        scope: Scope
     ): ([x] =>> FlowOp[F, x]) ~> F =
       new FunctionK[[x] =>> FlowOp[F, x], F]:
         def apply[A](fa: FlowOp[F, A]): F[A] =
@@ -73,10 +87,10 @@ object DslInterpreter:
 
             case Send(event, senderOverride, receiver, receivers) =>
               val source = senderOverride.getOrElse(processState.process.ref)
-              val first  = send(source, event, receiver, execTrace)
+              val first  = send(source, event, receiver, execTrace, scope)
               if receivers.nonEmpty then
                 first >> receivers.foldLeft(effect.pure(())) { (acc, next) =>
-                  acc >> send(source, event, next, execTrace)
+                  acc >> send(source, event, next, execTrace, scope)
                 }
               else first
 
@@ -84,25 +98,25 @@ object DslInterpreter:
               runWithSender
                 .asInstanceOf[ProcessRef[Event] => DslF[F, A]]
                 .apply(sender.asInstanceOf[ProcessRef[Event]])
-                .foldMap(interpret(sender, processState, execTrace))
+                .foldMap(interpret(sender, processState, execTrace, scope))
 
             case Forward(event, receivers) =>
               receivers
                 .foldLeft(effect.pure(())) { (acc, receiver) =>
-                  acc >> send(sender, event, receiver, execTrace)
+                  acc >> send(sender, event, receiver, execTrace, scope)
                 }
 
             case Par(flow) =>
               flow
                 .asInstanceOf[DslF[F, Unit]]
-                .foldMap(interpret(sender, processState, execTrace))
+                .foldMap(interpret(sender, processState, execTrace, scope))
 
             case Fork(flow) =>
               effect
                 .start(
                   flow
                     .asInstanceOf[DslF[F, A]]
-                    .foldMap(interpret(sender, processState, execTrace))
+                    .foldMap(interpret(sender, processState, execTrace, scope))
                 )
                 .map(fiber => Fiber.RuntimeFiber(fiber).asInstanceOf[A])
 
@@ -120,12 +134,12 @@ object DslInterpreter:
                 .suspend(
                   thunk()
                     .asInstanceOf[DslF[F, A]]
-                    .foldMap(interpret(sender, processState, execTrace))
+                    .foldMap(interpret(sender, processState, execTrace, scope))
                 )
 
             case Race(first, second) =>
-              val first0  = first.asInstanceOf[DslF[F, Any]].foldMap(interpret(sender, processState, execTrace))
-              val second0 = second.asInstanceOf[DslF[F, Any]].foldMap(interpret(sender, processState, execTrace))
+              val first0  = first.asInstanceOf[DslF[F, Any]].foldMap(interpret(sender, processState, execTrace, scope))
+              val second0 = second.asInstanceOf[DslF[F, Any]].foldMap(interpret(sender, processState, execTrace, scope))
               effect.race(first0, second0).asInstanceOf[F[A]]
 
             case Offload(body) =>
@@ -134,7 +148,7 @@ object DslInterpreter:
                 fiber <- effect.startBlocking(
                   body()
                     .asInstanceOf[DslF[F, Any]]
-                    .foldMap(interpret(sender, processState, execTrace))
+                    .foldMap(interpret(sender, processState, execTrace, scope))
                     .map(_ => Right(()))
                     .handleErrorWith(error => effect.pure(Left(error)))
                     .flatMap(outcome => done.complete(outcome).void)
@@ -149,18 +163,24 @@ object DslInterpreter:
               effect.raiseError(error)
 
             case HandleError(body, onError) =>
-              body().asInstanceOf[DslF[F, A]].foldMap(interpret(sender, processState, execTrace)).handleErrorWith {
-                error =>
-                  onError(error).asInstanceOf[DslF[F, A]].foldMap(interpret(sender, processState, execTrace))
-              }
+              body()
+                .asInstanceOf[DslF[F, A]]
+                .foldMap(interpret(sender, processState, execTrace, scope))
+                .handleErrorWith { error =>
+                  onError(error).asInstanceOf[DslF[F, A]].foldMap(interpret(sender, processState, execTrace, scope))
+                }
 
             case Halt(ref) =>
               context.remove(ref).void
 
             case Guarantee(body, finalizer) =>
               effect
-                .guarantee(body().asInstanceOf[DslF[F, Any]].foldMap(interpret(sender, processState, execTrace))) {
-                  finalizer().asInstanceOf[DslF[F, Unit]].foldMap(interpret(sender, processState, execTrace))
+                .guarantee(
+                  body().asInstanceOf[DslF[F, Any]].foldMap(interpret(sender, processState, execTrace, scope))
+                ) {
+                  finalizer()
+                    .asInstanceOf[DslF[F, Unit]]
+                    .foldMap(interpret(sender, processState, execTrace, scope))
                 }
                 .void
 
@@ -175,18 +195,29 @@ object DslInterpreter:
                   )
                   .void
 
+            case WithScope(f) =>
+              f.asInstanceOf[Scope => DslF[F, A]]
+                .apply(scope)
+                .foldMap(interpret(sender, processState, execTrace, scope))
+
+            case MapScope(f, body) =>
+              body
+                .asInstanceOf[DslF[F, A]]
+                .foldMap(interpret(sender, processState, execTrace, f(scope)))
+
     private def send(
         sender: ProcessRef.Unknown,
         eventThunk: () => Event,
         receiver: ProcessRef.Unknown,
-        execTrace: ExecutionTrace
+        execTrace: ExecutionTrace,
+        scope: Scope
     ): F[Unit] =
       effect.suspend {
         val event = context.eventTransformers.get(receiver) match
           case Some(transformer) => transformer.transform(eventThunk())
           case None              => eventThunk()
 
-        val envelope = Envelope(sender, event, receiver)
+        val envelope = Envelope(sender, event, receiver, scope)
         context.addToEventLog(envelope) >>
           context.schedule(Deliver(envelope, execTrace.add(envelope.id))).flatMap {
             case ProcessQueueIsFull => context.eventStore.write(envelope)

--- a/parapet-core/src/main/scala/io/parapet/core/Scheduler.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Scheduler.scala
@@ -249,7 +249,7 @@ object Scheduler:
 
     def submit(task: Task[F]): F[SubmissionResult] =
       task match
-        case deliverTask @ Deliver(envelope @ Envelope(sender, event, receiver), _) =>
+        case deliverTask @ Deliver(envelope @ Envelope(sender, event, receiver, _), _) =>
           effect.suspend(
             context.getProcessState(receiver) match
               case None =>
@@ -492,7 +492,7 @@ object Scheduler:
                       for
                         flow    <- effect.delay(process(event))
                         effect0 <- effect.pure(
-                          flow.foldMap(interpreter.interpret(sender, processState, task.execTrace))
+                          flow.foldMap(interpreter.interpret(sender, processState, task.execTrace, envelope.scope))
                         )
                         _ <- runEffect(
                           effect0,

--- a/parapet-core/src/main/scala/io/parapet/core/processes/DeadLetterProcess.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/processes/DeadLetterProcess.scala
@@ -32,7 +32,7 @@ object DeadLetterProcess:
     private val logger        = Logger(LoggerFactory.getLogger(getClass.getCanonicalName))
     override val name: String = s"${DeadLetterRef.value}-logging"
 
-    override val handle: Receive = { case DeadLetter(Envelope(sender, event, receiver), error) =>
+    override val handle: Receive = { case DeadLetter(Envelope(sender, event, receiver, _), error) =>
       val mdcFields: MDCFields = Map(
         "processRef"  -> ref,
         "processName" -> name,

--- a/parapet-core/src/test/scala/io/parapet/core/ScopeSpec.scala
+++ b/parapet-core/src/test/scala/io/parapet/core/ScopeSpec.scala
@@ -1,0 +1,105 @@
+package io.parapet.core
+
+import io.parapet.core.Dsl.{DslF, WithDsl}
+import io.parapet.core.ScopeSpec.*
+import io.parapet.core.TestUtils.*
+import io.parapet.core.TestUtils.given
+import io.parapet.syntax.FlowSyntax
+import io.parapet.{Event, ProcessRef, Scope}
+import org.scalatest.OptionValues.*
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers.*
+
+import java.util.concurrent.atomic.AtomicReference
+
+class ScopeSpec extends AnyFunSuite with WithDsl[TestIO] with FlowSyntax[TestIO]:
+
+  import dsl.*
+
+  private val targetRef = ProcessRef[Event]("target")
+
+  test("withScope sees the initial reader-context scope") {
+    val seen    = new AtomicReference[Scope](Scope.empty)
+    val fixture = new RuntimeFixture
+
+    val program: DslF[TestIO, Unit] =
+      withScope(s => eval(seen.set(s)))
+
+    fixture.run(program, Scope.empty.put(Tag, "hello"))
+
+    seen.get().get(Tag) shouldBe Some("hello")
+  }
+
+  test("mapScope only applies to its body; outer scope is restored for subsequent sends") {
+    val fixture = new RuntimeFixture
+
+    val program: DslF[TestIO, Unit] =
+      mapScope(_.put(Tag, "inside")) {
+        Ping ~> targetRef
+      } ++ Pong ~> targetRef
+
+    fixture.run(program)
+
+    val byEvent = fixture.captured.map(env => env.event -> env.scope.get(Tag)).toList
+    byEvent shouldBe List(
+      Ping -> Some("inside"),
+      Pong -> None
+    )
+  }
+
+  test("an outbound ~> stamps the current scope onto the envelope") {
+    val fixture = new RuntimeFixture
+
+    val program: DslF[TestIO, Unit] = Ping ~> targetRef
+
+    fixture.run(program, Scope.empty.put(Tag, "from-inbound"))
+
+    fixture.captured should have size 1
+    fixture.captured.head.scope.get(Tag).value shouldBe "from-inbound"
+  }
+
+  test("reply carries the current scope back to the original sender") {
+    val fixture = new RuntimeFixture
+
+    val program: DslF[TestIO, Unit] = reply(Pong)
+
+    fixture.runWithSender(
+      sender = targetRef,
+      program = program,
+      scope = Scope.empty.put(Tag, "round-trip")
+    )
+
+    fixture.captured should have size 1
+    val replyEnv = fixture.captured.head
+    replyEnv.event shouldBe Pong
+    replyEnv.receiver shouldBe targetRef
+    replyEnv.scope.get(Tag).value shouldBe "round-trip"
+  }
+
+  test("forward stamps the current scope and preserves the original sender") {
+    val fixture = new RuntimeFixture
+
+    val program: DslF[TestIO, Unit] = forward(Ping, targetRef)
+
+    fixture.runWithSender(
+      sender = ProcessRef[Event]("origin"),
+      program = program,
+      scope = Scope.empty.put(Tag, "via-proxy")
+    )
+
+    fixture.captured should have size 1
+    val env = fixture.captured.head
+    env.event shouldBe Ping
+    env.receiver shouldBe targetRef
+    env.sender shouldBe ProcessRef[Event]("origin")
+    env.scope.get(Tag).value shouldBe "via-proxy"
+  }
+
+object ScopeSpec:
+
+  private case object Ping extends Event
+
+  private case object Pong extends Event
+
+  private case object Tag extends Scope.Key[String]:
+    val name: String = "io.parapet.test.tag"

--- a/parapet-core/src/test/scala/io/parapet/core/TestUtils.scala
+++ b/parapet-core/src/test/scala/io/parapet/core/TestUtils.scala
@@ -1,9 +1,12 @@
 package io.parapet.core
 
 import io.parapet.core.Dsl.*
+import io.parapet.core.Parapet.ParConfig
+import io.parapet.core.Scheduler.{Deliver, SubmissionResult, Task}
+import io.parapet.core.processes.Noop
 import io.parapet.effect.{Effect, EffectFiber, Monad}
 import io.parapet.free.FunctionK
-import io.parapet.{Event, ProcessRef}
+import io.parapet.{Envelope, Event, ProcessRef, Scope}
 
 import java.util.concurrent.CancellationException
 import scala.collection.mutable.ListBuffer
@@ -191,3 +194,57 @@ object TestUtils:
 
         case Dsl.Unlock(_) =>
           ().asInstanceOf[A]
+
+        case WithScope(f) =>
+          f.asInstanceOf[Scope => DslF[Id, A]].apply(Scope.empty).foldMap(this)
+
+        case MapScope(_, body) =>
+          body.asInstanceOf[DslF[Id, A]].foldMap(this)
+
+  /** Lightweight fixture for tests that need to exercise the real [[DslInterpreter.Impl]].
+    */
+  final class RuntimeFixture:
+    val captured: ListBuffer[Envelope] = ListBuffer.empty
+
+    private val scheduler: Scheduler[TestIO] = new Scheduler[TestIO]:
+      def start: TestIO[Unit] = TestIO.unit
+
+      def submit(task: Task[TestIO]): TestIO[SubmissionResult] = task match
+        case Deliver(env, _) => TestIO.delay { captured += env; Scheduler.Ok }
+        case _               => TestIO.pure(Scheduler.Ok)
+
+    val context: Context[TestIO] =
+      Context[TestIO](ParConfig.default, EventStore.stub[TestIO], EventTransformers.empty).unsafeRun()
+
+    context.start(scheduler).unsafeRun()
+
+    /** A no-op process used as the "running" process for outbound sends. Its ref becomes the default sender. */
+    private val noop: Noop[TestIO] = new Noop[TestIO]
+    context.register(ProcessRef.SystemRef, noop).unsafeRun()
+
+    captured.clear() // drop any boot-time envelopes captured by the stub scheduler
+
+    private val impl = DslInterpreter[TestIO](context)
+
+    /** Interprets `program` with [[noop]] as the running-process context and `sender` as the (untyped) sender for any
+      * `WithSender` lookups.
+      */
+    def runWithSender[A](
+        sender: ProcessRef.Unknown,
+        program: DslF[TestIO, A],
+        scope: Scope = Scope.empty
+    ): A =
+      program
+        .foldMap(
+          impl.interpret(
+            sender,
+            context.getProcessState(noop.ref).get,
+            ExecutionTrace.Dummy,
+            scope
+          )
+        )
+        .unsafeRun()
+
+    /** Convenience overload using [[io.parapet.ProcessRef.UndefinedRef]] as the sender. */
+    def run[A](program: DslF[TestIO, A], scope: Scope = Scope.empty): A =
+      runWithSender(ProcessRef.UndefinedRef, program, scope)

--- a/parapet-core/src/test/scala/io/parapet/core/TestUtils.scala
+++ b/parapet-core/src/test/scala/io/parapet/core/TestUtils.scala
@@ -201,8 +201,6 @@ object TestUtils:
         case MapScope(_, body) =>
           body.asInstanceOf[DslF[Id, A]].foldMap(this)
 
-  /** Lightweight fixture for tests that need to exercise the real [[DslInterpreter.Impl]].
-    */
   final class RuntimeFixture:
     val captured: ListBuffer[Envelope] = ListBuffer.empty
 
@@ -218,7 +216,6 @@ object TestUtils:
 
     context.start(scheduler).unsafeRun()
 
-    /** A no-op process used as the "running" process for outbound sends. Its ref becomes the default sender. */
     private val noop: Noop[TestIO] = new Noop[TestIO]
     context.register(ProcessRef.SystemRef, noop).unsafeRun()
 
@@ -226,9 +223,6 @@ object TestUtils:
 
     private val impl = DslInterpreter[TestIO](context)
 
-    /** Interprets `program` with [[noop]] as the running-process context and `sender` as the (untyped) sender for any
-      * `WithSender` lookups.
-      */
     def runWithSender[A](
         sender: ProcessRef.Unknown,
         program: DslF[TestIO, A],
@@ -245,6 +239,5 @@ object TestUtils:
         )
         .unsafeRun()
 
-    /** Convenience overload using [[io.parapet.ProcessRef.UndefinedRef]] as the sender. */
     def run[A](program: DslF[TestIO, A], scope: Scope = Scope.empty): A =
       runWithSender(ProcessRef.UndefinedRef, program, scope)

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/BlockingSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/BlockingSpec.scala
@@ -125,7 +125,7 @@ abstract class BlockingSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
     eventStore.get(server.ref) shouldBe Seq(Ping)
     eventStore.get(client.ref).headOption.value should matchPattern {
       case Failure(
-            Envelope(client.`ref`, Trigger, server.`ref`),
+            Envelope(client.`ref`, Trigger, server.`ref`, _),
             EventHandlingException(_, ServerError)
           ) =>
     }

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
@@ -340,7 +340,10 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
       }
     }
 
-    unsafeRun(createApp(ct.pure(Seq(client, server))).run)
+    assertThrows[java.util.concurrent.TimeoutException] {
+      // late reply for the Request(1) should not be delivered
+      unsafeRun(eventStore.await(3, createApp(ct.pure(Seq(client, server))).run, timeout = 5.seconds))
+    }
     eventStore.get(clientRef) shouldBe Seq(TimedOut, Response(2))
   }
 

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
@@ -309,9 +309,7 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
 
   test("channel drops a stale reply from the active receiver via causation correlation") {
     // The server's first response is intentionally slow enough to time out the first request, then arrives at the
-    // channel mailbox while the channel is already waiting for the second request's response. With sender-only
-    // matching this stale envelope would complete the new request with the old payload; with causation matching
-    // it is silently dropped because its scope.Causation does not match the in-flight request's id.
+    // channel mailbox while the channel is already waiting for the second request's response.
     val eventStore = new EventStore[F, Event]
     val clientRef  = ProcessRef[Event]("stale-reply-client")
 
@@ -342,7 +340,7 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
       }
     }
 
-    unsafeRun(eventStore.await(2, createApp(ct.pure(Seq(client, server))).run, timeout = 5.seconds))
+    unsafeRun(createApp(ct.pure(Seq(client, server))).run)
     eventStore.get(clientRef) shouldBe Seq(TimedOut, Response(2))
   }
 

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ChannelSpec.scala
@@ -307,6 +307,45 @@ abstract class ChannelSpec[F[_]] extends AnyFunSuite with IntegrationSpec[F] {
     eventStore.get(client.ref) shouldBe Seq(WrongSender)
   }
 
+  test("channel drops a stale reply from the active receiver via causation correlation") {
+    // The server's first response is intentionally slow enough to time out the first request, then arrives at the
+    // channel mailbox while the channel is already waiting for the second request's response. With sender-only
+    // matching this stale envelope would complete the new request with the old payload; with causation matching
+    // it is silently dropped because its scope.Causation does not match the in-flight request's id.
+    val eventStore = new EventStore[F, Event]
+    val clientRef  = ProcessRef[Event]("stale-reply-client")
+
+    val ch = Channel[F, Request, Response]
+
+    val server = new Process[F, Request, Response] {
+      override val ref: ProcessRef[Request] = ProcessRef("stale-reply-server")
+
+      override def handle: Receive = { case Request(seq) =>
+        if seq == 1 then delay(200.millis) ++ reply(Response(seq))
+        else reply(Response(seq))
+      }
+    }
+
+    val client = new Process[F, Event, Event] {
+      override val ref: ProcessRef[Event] = clientRef
+
+      override def handle: Receive = { case Start =>
+        register(ref, ch) ++
+          ch.send(Request(1), server.ref, 50.millis).flatMap {
+            case SFailure(_: ChannelTimeoutException) => eval(eventStore.add(ref, TimedOut))
+            case other                                => eval(fail(s"expected timeout for request 1, got $other"))
+          } ++
+          ch.send(Request(2), server.ref, 2.seconds).flatMap {
+            case Success(Response(2)) => eval(eventStore.add(ref, Response(2)))
+            case other                => eval(fail(s"expected fresh Response(2), got $other"))
+          }
+      }
+    }
+
+    unsafeRun(eventStore.await(2, createApp(ct.pure(Seq(client, server))).run, timeout = 5.seconds))
+    eventStore.get(clientRef) shouldBe Seq(TimedOut, Response(2))
+  }
+
   test("channel surfaces interruption when stopped while a request is in flight") {
     val eventStore = new EventStore[F, Event]
     val clientRef  = ProcessRef("client")

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ErrorHandlingSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ErrorHandlingSpec.scala
@@ -34,7 +34,7 @@ abstract class ErrorHandlingSpec[F[_]] extends AnyWordSpec with IntegrationSpec[
 
         clientEventStore.size shouldBe 1
         clientEventStore.get(client.ref).headOption.value should matchPattern {
-          case Failure(Envelope(client.`ref`, Request, faultyServer.`ref`), _: EventHandlingException) =>
+          case Failure(Envelope(client.`ref`, Request, faultyServer.`ref`, _), _: EventHandlingException) =>
         }
       }
     }
@@ -64,7 +64,7 @@ abstract class ErrorHandlingSpec[F[_]] extends AnyWordSpec with IntegrationSpec[
 
         eventStore.size shouldBe 1
         eventStore.get(deadLetter.ref).headOption.value should matchPattern {
-          case DeadLetter(Envelope(client.`ref`, Request, server.`ref`), _: EventHandlingException) =>
+          case DeadLetter(Envelope(client.`ref`, Request, server.`ref`, _), _: EventHandlingException) =>
         }
 
       }
@@ -96,7 +96,7 @@ abstract class ErrorHandlingSpec[F[_]] extends AnyWordSpec with IntegrationSpec[
 
         eventStore.size shouldBe 1
         eventStore.get(deadLetter.ref).headOption.value should matchPattern {
-          case DeadLetter(Envelope(client.`ref`, Request, server.`ref`), _: EventHandlingException) =>
+          case DeadLetter(Envelope(client.`ref`, Request, server.`ref`, _), _: EventHandlingException) =>
         }
       }
     }

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/EventDeliverySpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/EventDeliverySpec.scala
@@ -123,7 +123,7 @@ abstract class EventDeliverySpec[F[_]] extends AnyFlatSpec with IntegrationSpec[
 
     eventStore.size shouldBe 1
     eventStore.get(deadLetter.ref).headOption.value should matchPattern {
-      case DeadLetter(Envelope(client.`ref`, UnknownEvent, server.`ref`), _: EventMatchException) =>
+      case DeadLetter(Envelope(client.`ref`, UnknownEvent, server.`ref`, _), _: EventMatchException) =>
     }
   }
 

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ProcessSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ProcessSpec.scala
@@ -101,7 +101,7 @@ abstract class ProcessSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
         eventStore.size shouldBe 1
 
         eventStore.get(deadLetter.ref).headOption.value should matchPattern {
-          case DeadLetter(Envelope(TestSystemRef, Result(42), composed.`ref`), _: EventMatchException) =>
+          case DeadLetter(Envelope(TestSystemRef, Result(42), composed.`ref`, _), _: EventMatchException) =>
         }
 
       }

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/scheduler/SchedulerSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/scheduler/SchedulerSpec.scala
@@ -45,7 +45,7 @@ abstract class SchedulerSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
 
         eventStore.size shouldBe 1
         eventStore.get(deadLetter.ref).headOption.value should matchPattern {
-          case DeadLetter(Envelope(client.`ref`, Request, unknownProcess.`ref`), _: UnknownProcessException) =>
+          case DeadLetter(Envelope(client.`ref`, Request, unknownProcess.`ref`, _), _: UnknownProcessException) =>
         }
       }
     }
@@ -85,7 +85,7 @@ abstract class SchedulerSpec[F[_]] extends AnyWordSpec with IntegrationSpec[F] {
 
         eventStore.size shouldBe 1
         eventStore.get(deadLetter.ref).headOption.value should matchPattern {
-          case DeadLetter(Envelope(client.`ref`, NamedRequest("3"), slowServer.`ref`), _: EventDeliveryException) =>
+          case DeadLetter(Envelope(client.`ref`, NamedRequest("3"), slowServer.`ref`, _), _: EventDeliveryException) =>
         }
 
       }


### PR DESCRIPTION
## Scope

New `io.parapet.Scope` - opaque, typed key/value metadata.

## DSL ops

Two new operators:

- `withScope(f: Scope => DslF[F, A])` - read the current scope.
- `mapScope(f: Scope => Scope)(body)` - allows to override current scope.

## Channel fix

`Channel` was susceptible to a stale-reply race: a slow reply to a timed-out request could land in a fresh in-flight request and complete the next caller with the wrong response. `Channel` now set `Scope.Causation` per request via `mapScope` and matches replies by causation id. A late reply from a previously timed-out request is silently dropped instead of completing the next caller.