### PR TITLE
Recovery

### DIFF
--- a/parapet-core/src/main/scala/io/parapet/ParApp.scala
+++ b/parapet-core/src/main/scala/io/parapet/ParApp.scala
@@ -170,20 +170,12 @@ trait ParApp[F[_]] extends FlowSyntax[F]:
         journalStorage = Option.when(config.journal.enabled)(journalStorage),
         codecRegistry = eventCodecs
       )
-      interp   = interpreter(context)
-      recovery = new core.Recovery(context, interp)
-      // Seed the sequencers before any envelope is created (bind creates the system processes' Start envelopes), so a
-      // restart continues past the delivery seq and envelope ids already in the journal.
-      _                 <- recovery.seedSequencers()
+      interp = interpreter(context)
       scheduler         <- Scheduler(config.schedulerConfig, context, interp)
       _                 <- context.bind(scheduler)
       deadLetterProcess <- deadLetter
-      // Recovery owns boot: register + restore the processes, then re-fold the recorded journal onto them so each
-      // catches up from its snapshot boundary to the last recorded delivery. No-op re-fold when the journal is empty.
-      _ <- recovery.boot(ps.toList :+ deadLetterProcess)
-      // Start the workers last, so the first live delivery already sees the reconstructed state and the correct seq
-      // high-water.
-      _ <- scheduler.start
+      _                 <- context.boot(ps.toList :+ deadLetterProcess, interp)
+      _                 <- scheduler.start
     yield ()
 
   /** Standard JVM entry point; runs [[run]] under [[unsafeRun]]. Subclasses normally do not need to override this.

--- a/parapet-core/src/main/scala/io/parapet/ParApp.scala
+++ b/parapet-core/src/main/scala/io/parapet/ParApp.scala
@@ -170,15 +170,19 @@ trait ParApp[F[_]] extends FlowSyntax[F]:
         journalStorage = Option.when(config.journal.enabled)(journalStorage),
         codecRegistry = eventCodecs
       )
+      interp   = interpreter(context)
+      recovery = new core.Recovery(context, interp)
       // Seed the sequencers before any envelope is created (bind creates the system processes' Start envelopes), so a
       // restart continues past the delivery seq and envelope ids already in the journal.
-      _                 <- context.seedSequencersFromJournal
-      scheduler         <- Scheduler(config.schedulerConfig, context, interpreter(context))
+      _                 <- recovery.seedSequencers()
+      scheduler         <- Scheduler(config.schedulerConfig, context, interp)
       _                 <- context.bind(scheduler)
       deadLetterProcess <- deadLetter
-      _                 <- context.registerAll(ps.toList :+ deadLetterProcess)
-      // Start the workers last: registerAll has restored every snapshotable process and advanced the delivery
-      // sequence past their snapshots, so the first delivery a worker makes already sees the correct seq high-water.
+      // Recovery owns boot: register + restore the processes, then re-fold the recorded journal onto them so each
+      // catches up from its snapshot boundary to the last recorded delivery. No-op re-fold when the journal is empty.
+      _ <- recovery.boot(ps.toList :+ deadLetterProcess)
+      // Start the workers last, so the first live delivery already sees the reconstructed state and the correct seq
+      // high-water.
       _ <- scheduler.start
     yield ()
 

--- a/parapet-core/src/main/scala/io/parapet/ProcessRef.scala
+++ b/parapet-core/src/main/scala/io/parapet/ProcessRef.scala
@@ -18,10 +18,16 @@ import java.util.UUID
   *   companion constants).
   */
 final case class ProcessRef[-I <: Event](private[parapet] val value: String):
+  /** Derives a stable address for a direct child of this process. */
+  def child[ChildIn <: Event](name: String): ProcessRef[ChildIn] =
+    ProcessRef.childOf(this, name)
+
   override def toString: String = value
 
 /** Factory and well-known [[ProcessRef]] constants reserved by the parapet runtime. */
 object ProcessRef:
+
+  private val SegmentPattern = "[A-Za-z0-9][A-Za-z0-9._-]*".r
 
   /** A ref whose accepted event protocol is intentionally unknown.
     *
@@ -57,6 +63,10 @@ object ProcessRef:
 
   private[parapet] val RuntimeProcessRefs: Set[Unknown] = Set(SystemRef, NoopRef)
 
+  /** Creates a named root reference. */
+  def root[I <: Event](name: String): ProcessRef[I] =
+    new ProcessRef[I](validatedSegment(name))
+
   /** Allocates a fresh, globally unique reference backed by a JDK [[UUID]]. */
   def apply[I <: Event](): ProcessRef[I] =
     jdkUUIDRef[I]
@@ -66,3 +76,14 @@ object ProcessRef:
     */
   def jdkUUIDRef[I <: Event]: ProcessRef[I] =
     new ProcessRef[I](UUID.randomUUID().toString)
+
+  private def childOf[I <: Event](parent: Unknown, name: String): ProcessRef[I] =
+    require(parent.value.nonEmpty, "a child reference requires a non-empty parent reference")
+    new ProcessRef[I](s"${parent.value}/${validatedSegment(name)}")
+
+  private def validatedSegment(value: String): String =
+    require(
+      SegmentPattern.pattern.matcher(value).matches(),
+      s"invalid process reference segment '$value': expected [A-Za-z0-9][A-Za-z0-9._-]*"
+    )
+    value

--- a/parapet-core/src/main/scala/io/parapet/ProcessRef.scala
+++ b/parapet-core/src/main/scala/io/parapet/ProcessRef.scala
@@ -55,6 +55,8 @@ object ProcessRef:
   /** Reference to the no-op process which silently swallows any events sent to it. */
   val NoopRef: ProcessRef[Event] = ProcessRef(s"$ParapetPrefix-noop")
 
+  private[parapet] val RuntimeProcessRefs: Set[Unknown] = Set(SystemRef, NoopRef)
+
   /** Allocates a fresh, globally unique reference backed by a JDK [[UUID]]. */
   def apply[I <: Event](): ProcessRef[I] =
     jdkUUIDRef[I]

--- a/parapet-core/src/main/scala/io/parapet/core/BootMode.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/BootMode.scala
@@ -2,9 +2,10 @@ package io.parapet.core
 
 /** Whether the runtime is re-folding recorded history or running normally.
   *
-  *   - [[Live]]: normal operation; handlers' outward effects take effect.
-  *   - [[Replaying]]: recovery/replay is driving recorded deliveries; the interpreter suppresses outward effects
-  *     (sends, timers) so recorded history is not re-emitted. Structural operations (process registration) still run.
+  *   - [[Live]]: normal operation. Processes receive {{Start}} event and fully ready to perform any operation.
+  *   - [[Replaying]]: starts the app in recovery/replay mode: processes states are recovered from snapshots, events are
+  *     replied. Some DSL operations are silenced (no-op), but it doesn't have any impact on process behavior. once a
+  *     process receives {{Start}} event it can go live.
   */
 enum BootMode:
   case Live, Replaying

--- a/parapet-core/src/main/scala/io/parapet/core/BootMode.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/BootMode.scala
@@ -1,0 +1,10 @@
+package io.parapet.core
+
+/** Whether the runtime is re-folding recorded history or running normally.
+  *
+  *   - [[Live]]: normal operation; handlers' outward effects take effect.
+  *   - [[Replaying]]: recovery/replay is driving recorded deliveries; the interpreter suppresses outward effects
+  *     (sends, timers) so recorded history is not re-emitted. Structural operations (process registration) still run.
+  */
+enum BootMode:
+  case Live, Replaying

--- a/parapet-core/src/main/scala/io/parapet/core/Channel.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Channel.scala
@@ -1,7 +1,7 @@
 package io.parapet.core
 
 import io.parapet.core.Dsl.DslF
-import io.parapet.core.Events.{Failure, Start, Stop}
+import io.parapet.core.Events.{Failure, Stop, SystemEvent}
 import io.parapet.effect.{Deferred, Effect}
 import io.parapet.effect.Monad.*
 import io.parapet.{Event, ProcessRef, Scope}
@@ -56,12 +56,14 @@ class Channel[F[_], In <: Event, Out <: Event](
   }
 
   private def waitForResponse: Receive = {
-    case Start => unit
-    case Stop  =>
+    case Stop =>
       inFlight match
         case Some(active) =>
           complete(active, scala.util.Failure(ChannelInterruptedException("channel has been closed")))
         case None => unit
+    // Lifecycle events (Start, Initialize, Restored, and any future ones) are never responses. Ignore them so a
+    // request that begins before the channel has drained its own queued lifecycle events is not failed by one.
+    case _: SystemEvent => unit
     case req: Request[F, Out] @unchecked =>
       suspend(
         req.result

--- a/parapet-core/src/main/scala/io/parapet/core/Context.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Context.scala
@@ -219,13 +219,13 @@ class Context[F[_]](
 
   /** Restores and replays the application, then schedules [[Events.Start]] for the live phase. */
   private[parapet] def boot(processes0: List[Process[F, ?, ?]], interpreter: Interpreter[F]): F[Unit] =
-    val recovery = new Recovery(self, interpreter)
-
-    effect.delay { bootMode = BootMode.Replaying } >>
-      recovery.seedSequencers() >>
-      recovery.boot(processes0) >>
-      effect.delay { bootMode = BootMode.Live } >>
-      Monad.sequence(getProcesses.map(process => sendStartEvent(process.ref))).void
+    if snapshotEnabled || journalEnabled then
+      val recovery = new Recovery(self, interpreter)
+      effect.delay { bootMode = BootMode.Replaying } >> 
+        recovery.seedSequencers() >>
+        recovery.boot(processes0) >>
+        effect.delay { bootMode = BootMode.Live } 
+    else effect.pure(()) >> Monad.sequence(getProcesses.map(process => sendStartEvent(process.ref))).void
 
   /** The snapshot manager, if snapshotting is enabled; used by [[io.parapet.core.Recovery]] to restore at boot. */
   private[parapet] def snapshots: Option[SnapshotManager[F]] = snapshotManager
@@ -281,15 +281,14 @@ object Context:
       journalStorage: Option[JournalStore[F]] = None,
       codecRegistry: EventCodecRegistry = EventCodecRegistry.empty
   )(using effect: Effect[F]): F[Context[F]] =
-    val codecs = EventCodecRegistry.withSystemCodecs(codecRegistry)
     for
       snapshots <- buildWithStorage(config.snapshot.enabled, snapshotStorage, "snapshotting")(
         SnapshotManager[F](_, Clock(), config.snapshot.queueCapacity)
       )
       recorder <- buildWithStorage(config.journal.enabled, journalStorage, "journal")(store =>
-        effect.pure(DeliveryRecorder.fresh(store, codecs, config.journal))
+        effect.pure(DeliveryRecorder.fresh(store, codecRegistry, config.journal))
       )
-    yield new Context[F](config, eventTransformers, snapshots, recorder, codecs)
+    yield new Context[F](config, eventTransformers, snapshots, recorder, codecRegistry)
 
   private def buildWithStorage[F[_], S, M](enabled: Boolean, storage: Option[S], name: String)(
       build: S => F[M]
@@ -383,11 +382,6 @@ object Context:
     /** Whether this process opts into snapshotting. */
     val snapshotable: Boolean = process.isInstanceOf[snapshot.Snapshotable]
 
-    /** The delivery `seq` this process was restored to at boot, or `0` if it started fresh. Replay skips entries with
-      * `seq <= restoredSeq` (already folded into the snapshot).
-      */
-    var restoredSeq: Long = 0L
-
     /** Bookkeeping for offloaded operations spawned by this process. */
     def offloads: OffloadTracker[F] =
       offloadTracker
@@ -472,6 +466,7 @@ object Context:
       * earliest time-triggered snapshot is one interval after the process first did work.
       */
     def onDelivered(seq: Long): Unit =
+      if seq < lastSeq then throw IllegalStateException(s"seq=$seq < lastSeq=$lastSeq")
       eventsSinceSnapshot += 1
       lastSeq = seq
       if lastSnapshotNanos == Long.MinValue then lastSnapshotNanos = clock.nanoTime

--- a/parapet-core/src/main/scala/io/parapet/core/Context.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Context.scala
@@ -35,9 +35,9 @@ import scala.jdk.CollectionConverters.*
 class Context[F[_]](
     config: Parapet.ParConfig,
     val eventTransformers: EventTransformers,
-    private val snapshotManager: Option[SnapshotManager[F]],
-    private val recorder: Option[DeliveryRecorder[F]],
-    private val codecRegistry: EventCodecRegistry
+    private[core] val snapshotManager: Option[SnapshotManager[F]],
+    private[core] val recorder: Option[DeliveryRecorder[F]],
+    private[core] val codecRegistry: EventCodecRegistry
 )(using effect: Effect[F]):
   self =>
 
@@ -227,9 +227,6 @@ class Context[F[_]](
       effect.delay {
         bootMode = BootMode.Live
       } >> Monad.sequence(getProcesses.map(process => sendStartEvent(process.ref))).void
-
-  /** The snapshot manager, if snapshotting is enabled; used by [[io.parapet.core.Recovery]] to restore at boot. */
-  private[parapet] def snapshots: Option[SnapshotManager[F]] = snapshotManager
 
   /** Highest delivery `seq` recorded in the journal, or `None`; seeds the delivery counter at boot. */
   private[parapet] def journalMaxSeq: F[Option[Long]] = recorder.fold(effect.pure(Option.empty[Long]))(_.maxSeq)

--- a/parapet-core/src/main/scala/io/parapet/core/Context.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Context.scala
@@ -156,22 +156,25 @@ class Context[F[_]](
     effect.suspend {
       if !processes.containsKey(parent) then
         effect.raiseError(UnknownProcessException(s"process cannot be registered because parent $parent doesn't exist"))
-      else if parents.containsKey(child.ref) then
-        effect.raiseError(
-          new IllegalStateException(s"$child has been already registered. its parent=${parents.get(child.ref)}")
-        )
       else
         child.init(self)
         ProcessState(child, config, clock).flatMap { state =>
-          recordRegistration(parent, child.ref) >> effect.delay {
-            if processes.putIfAbsent(child.ref, state) != null then
-              throw new RuntimeException(s"duplicated process. ref = ${child.ref}")
-
-            parents.put(child.ref, parent)
-            graph.computeIfAbsent(parent, _ => ListBuffer.empty)
-            graph.computeIfPresent(parent, (_, values) => values :+ child.ref)
-            child.ref
-          }
+          effect
+            .delay {
+              if processes.putIfAbsent(child.ref, state) != null then
+                throw new IllegalStateException(s"duplicated process. ref = ${child.ref}")
+            }
+            .flatMap { _ =>
+              recordRegistration(parent, child.ref)
+                .handleErrorWith { error =>
+                  effect.delay(processes.remove(child.ref, state)).flatMap(_ => effect.raiseError(error))
+                } >> effect.delay {
+                parents.put(child.ref, parent)
+                graph.computeIfAbsent(parent, _ => ListBuffer.empty)
+                graph.computeIfPresent(parent, (_, values) => values :+ child.ref)
+                child.ref
+              }
+            }
         }
     }
 
@@ -258,7 +261,8 @@ class Context[F[_]](
     */
   def remove(ref: ProcessRef.Unknown): F[Boolean] =
     effect.delay {
-      graph.computeIfPresent(parents.get(ref), (_, values) => values -= ref)
+      val parent = parents.remove(ref)
+      if parent != null then graph.computeIfPresent(parent, (_, values) => values -= ref)
       processes.remove(ref) != null
     }
 

--- a/parapet-core/src/main/scala/io/parapet/core/Context.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Context.scala
@@ -73,6 +73,19 @@ class Context[F[_]](
   /** The codec for `event`, or `None` when its type is not registered */
   def codecFor(event: Event): Option[EventCodec] = codecRegistry.codecFor(event)
 
+  /** The codec that recorded entries under `tag`, or `None` when the tag is unknown - used to decode on replay. */
+  def codecForTag(tag: String): Option[EventCodec] = codecRegistry.codecForTag(tag)
+
+  private val bootModeRef = new AtomicReference[BootMode](BootMode.Live)
+
+  /** Current boot mode; [[BootMode.Replaying]] while recovery re-folds recorded history, else [[BootMode.Live]]. */
+  def bootMode: BootMode = bootModeRef.get
+
+  /** True while replaying recorded history - the interpreter suppresses outward effects. */
+  def replaying: Boolean = bootMode == BootMode.Replaying
+
+  private[parapet] def bootMode_=(mode: BootMode): Unit = bootModeRef.set(mode)
+
   /** Records `draft` in the delivery journal and returns its assigned delivery `seq`. Only valid when journalling is on
     * (the caller reaches this only for a journalable delivery).
     */
@@ -82,6 +95,10 @@ class Context[F[_]](
   /** Stops the journal, publishing any buffered tail. No-op when the journal is off. */
   def stopJournal: F[Unit] =
     recorder.fold(effect.pure(()))(_.close())
+
+  /** Recorded deliveries with `seq > afterSeq` in ascending order, or empty when the journal is off. For replay. */
+  def readJournal(afterSeq: Long): F[Vector[journal.JournalEntry]] =
+    recorder.fold(effect.pure(Vector.empty[journal.JournalEntry]))(_.read(afterSeq))
 
   private val processes = java.util.concurrent.ConcurrentHashMap[ProcessRef.Unknown, ProcessState[F]]()
   private val graph     = java.util.concurrent.ConcurrentHashMap[ProcessRef.Unknown, ListBuffer[ProcessRef.Unknown]]()
@@ -163,61 +180,43 @@ class Context[F[_]](
   def child(parent: ProcessRef.Unknown): Vector[ProcessRef.Unknown] =
     graph.getOrDefault(parent, ListBuffer.empty).toVector
 
-  /** Combination of [[register]] and dispatch of the initial [[Events.Start]] event. */
+  /** Combination of [[register]] and dispatch of the initial [[Events.Start]] event. Snapshot restore is applied by
+    * [[io.parapet.core.Recovery]] at boot, not here.
+    */
   def registerAndStart(parent: ProcessRef.Unknown, process: Process[F, ?, ?]): F[SubmissionResult] =
     register(parent, process) >> sendStartEvent(process.ref)
 
-  private def sendStartEvent(processRef: ProcessRef.Unknown): F[SubmissionResult] =
+  private[parapet] def sendStartEvent(processRef: ProcessRef.Unknown): F[SubmissionResult] =
     sendLifecycleEvent(processRef, Start)
 
-  private def sendLifecycleEvent(processRef: ProcessRef.Unknown, event: Events.SystemEvent): F[SubmissionResult] =
+  private[parapet] def sendLifecycleEvent(
+      processRef: ProcessRef.Unknown,
+      event: Events.SystemEvent
+  ): F[SubmissionResult] =
     scheduler.submit(Deliver(Envelope(ProcessRef.SystemRef, event, processRef)))
 
-  /** Registers a batch of root processes (parented to [[ProcessRef.SystemRef]]) and starts each.
-    */
+  /** Registers a batch of root processes (parented to [[ProcessRef.SystemRef]]) and starts each. */
   def registerAll(processes0: List[Process[F, ?, ?]]): F[List[ProcessRef.Unknown]] =
     registerAll(ProcessRef.SystemRef, processes0)
 
-  /** Registers a batch of processes under `parent`, then boots each: a [[Snapshotable]] process with a stored snapshot
-    * is restored and gets [[Events.Restored]]; everyone else gets [[Events.Start]].
-    *
-    * Restoring happens between register and the lifecycle event so a process's state is in place before it sees any
-    * event, and its `Start` initialization never runs over restored state.
+  /** Registers a batch of processes under `parent`, then sends each an [[Events.Start]]. Snapshot restore and journal
+    * re-fold are applied by [[io.parapet.core.Recovery]] at boot, not here.
     */
   def registerAll(parent: ProcessRef.Unknown, processes0: List[Process[F, ?, ?]]): F[List[ProcessRef.Unknown]] =
     for
-      _      <- Monad.sequence(processes0.map(register(parent, _)))
-      result <- Monad.sequence(processes0.map(boot))
-    yield result
+      refs <- Monad.sequence(processes0.map(register(parent, _)))
+      _    <- Monad.sequence(processes0.map(p => sendStartEvent(p.ref)))
+    yield refs
 
-  /** Advances the delivery-sequence and envelope-id counters past what the journal already holds. */
-  private[parapet] def seedSequencersFromJournal: F[Unit] =
-    recorder match
-      case None      => effect.pure(())
-      case Some(rec) =>
-        for
-          maxSeq <- rec.maxSeq
-          maxId  <- rec.maxEnvelopeId
-          _      <- effect.delay {
-            maxSeq.foreach(continueSeqAfter)
-            maxId.foreach(Envelope.continueIdAfter)
-          }
-        yield ()
+  /** The snapshot manager, if snapshotting is enabled; used by [[io.parapet.core.Recovery]] to restore at boot. */
+  private[parapet] def snapshots: Option[SnapshotManager[F]] = snapshotManager
 
-  /** Restores `process` from its latest snapshot when applicable, advances the delivery sequence past it, and delivers
-    * the matching lifecycle event ([[Events.Restored]] if restored, else [[Events.Start]]).
-    */
-  private def boot(process: Process[F, ?, ?]): F[ProcessRef.Unknown] =
-    val ref: ProcessRef.Unknown = process.ref
-    (snapshotManager, process) match
-      case (Some(manager), snapshotable: snapshot.Snapshotable) =>
-        manager.restoreLatest(ref, snapshotable).flatMap {
-          case Some(restored) =>
-            continueSeqAfter(restored.metadata.seq)
-            sendLifecycleEvent(ref, Events.Restored).as(ref)
-          case None => sendStartEvent(ref).as(ref)
-        }
-      case _ => sendStartEvent(ref).as(ref)
+  /** Highest delivery `seq` recorded in the journal, or `None`; seeds the delivery counter at boot. */
+  private[parapet] def journalMaxSeq: F[Option[Long]] = recorder.fold(effect.pure(Option.empty[Long]))(_.maxSeq)
+
+  /** Highest envelope id the journal refers to, or `None`; seeds the envelope-id counter at boot. */
+  private[parapet] def journalMaxEnvelopeId: F[Option[Long]] =
+    recorder.fold(effect.pure(Option.empty[Long]))(_.maxEnvelopeId)
 
   /** Snapshot of every [[Process]] currently registered (system + user). */
   def getProcesses: List[Process[F, ?, ?]] =
@@ -362,6 +361,11 @@ object Context:
 
     /** Whether this process opts into snapshotting. */
     val snapshotable: Boolean = process.isInstanceOf[snapshot.Snapshotable]
+
+    /** The delivery `seq` this process was restored to at boot, or `0` if it started fresh. Replay skips entries with
+      * `seq <= restoredSeq` (already folded into the snapshot). Written on the boot thread before workers start.
+      */
+    var restoredSeq: Long = 0L
 
     /** Bookkeeping for offloaded operations spawned by this process. */
     def offloads: OffloadTracker[F] =

--- a/parapet-core/src/main/scala/io/parapet/core/Context.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Context.scala
@@ -1,7 +1,8 @@
 package io.parapet.core
 
 import io.parapet.core.Context.*
-import io.parapet.core.Events.Start
+import io.parapet.core.DslInterpreter.Interpreter
+import io.parapet.core.Events.{Initialize, Registered, Start}
 import io.parapet.core.Queue.ChannelType
 import io.parapet.core.Scheduler.{Deliver, SubmissionResult, Task, TaskQueue}
 import io.parapet.core.exceptions.UnknownProcessException
@@ -122,14 +123,12 @@ class Context[F[_]](
     */
   private[core] def scheduler: Scheduler[F] = _scheduler
 
-  /** Binds `scheduler` to this context, creates the built-in system processes, and sends their initial [[Events.Start]]
-    * event. Must run before [[Scheduler.start]] - the scheduler refuses to start until it is bound. Called once during
-    * application boot.
+  /** Binds `scheduler` to this context and creates the built-in system processes. Must run before [[Scheduler.start]].
     */
   def bind(scheduler: Scheduler[F]): F[Unit] =
     effect.delay {
       _scheduler = scheduler
-    } >> createSysProcesses >> sendStartEvent(ProcessRef.SystemRef).void
+    } >> createSysProcesses
 
   private[core] def createSysProcesses: F[Unit] =
     for
@@ -145,8 +144,8 @@ class Context[F[_]](
     scheduler.submit(task)
 
   /** Registers `child` under `parent` in the supervision graph. The child receives a fresh [[ProcessState]] (mailbox,
-    * locks) and is wired into the [[Context]] but does not automatically receive a [[Events.Start]] - see
-    * [[registerAndStart]] for that.
+    * locks) and is wired into the [[Context]] but does not automatically receive lifecycle events - see
+    * [[registerAndStart]].
     *
     * @return
     *   the child's [[ProcessRef]], which equals `child.ref`.
@@ -164,7 +163,7 @@ class Context[F[_]](
       else
         child.init(self)
         ProcessState(child, config, clock).flatMap { state =>
-          effect.delay {
+          recordRegistration(parent, child.ref) >> effect.delay {
             if processes.putIfAbsent(child.ref, state) != null then
               throw new RuntimeException(s"duplicated process. ref = ${child.ref}")
 
@@ -176,15 +175,23 @@ class Context[F[_]](
         }
     }
 
+  private def recordRegistration(parent: ProcessRef.Unknown, child: ProcessRef.Unknown): F[Unit] =
+    if replaying then effect.pure(())
+    else
+      recorder match
+        case None    => effect.pure(())
+        case Some(_) =>
+          effect.delay(Envelope(ProcessRef.SystemRef, Registered(child), parent)).flatMap { envelope =>
+            admit(JournalDraft(envelope.id, envelope.sender, envelope.receiver, envelope.cause, envelope.event)).void
+          }
+
   /** Direct children of `parent` in the supervision graph. */
   def child(parent: ProcessRef.Unknown): Vector[ProcessRef.Unknown] =
     graph.getOrDefault(parent, ListBuffer.empty).toVector
 
-  /** Combination of [[register]] and dispatch of the initial [[Events.Start]] event. Snapshot restore is applied by
-    * [[io.parapet.core.Recovery]] at boot, not here.
-    */
+  /** Registers a live child and schedules [[Events.Initialize]] followed by [[Events.Start]]. */
   def registerAndStart(parent: ProcessRef.Unknown, process: Process[F, ?, ?]): F[SubmissionResult] =
-    register(parent, process) >> sendStartEvent(process.ref)
+    register(parent, process) >> sendLifecycleEvent(process.ref, Initialize) >> sendStartEvent(process.ref)
 
   private[parapet] def sendStartEvent(processRef: ProcessRef.Unknown): F[SubmissionResult] =
     sendLifecycleEvent(processRef, Start)
@@ -195,18 +202,26 @@ class Context[F[_]](
   ): F[SubmissionResult] =
     scheduler.submit(Deliver(Envelope(ProcessRef.SystemRef, event, processRef)))
 
-  /** Registers a batch of root processes (parented to [[ProcessRef.SystemRef]]) and starts each. */
+  /** Registers a batch of root processes and schedules [[Events.Initialize]] followed by [[Events.Start]]. */
   def registerAll(processes0: List[Process[F, ?, ?]]): F[List[ProcessRef.Unknown]] =
     registerAll(ProcessRef.SystemRef, processes0)
 
-  /** Registers a batch of processes under `parent`, then sends each an [[Events.Start]]. Snapshot restore and journal
-    * re-fold are applied by [[io.parapet.core.Recovery]] at boot, not here.
-    */
+  /** Registers and activates a batch of processes under `parent`. */
   def registerAll(parent: ProcessRef.Unknown, processes0: List[Process[F, ?, ?]]): F[List[ProcessRef.Unknown]] =
     for
       refs <- Monad.sequence(processes0.map(register(parent, _)))
-      _    <- Monad.sequence(processes0.map(p => sendStartEvent(p.ref)))
+      _    <- Monad.sequence(processes0.map(p => sendLifecycleEvent(p.ref, Initialize) >> sendStartEvent(p.ref)))
     yield refs
+
+  /** Restores and replays the application, then schedules [[Events.Start]] for the live phase. */
+  private[parapet] def boot(processes0: List[Process[F, ?, ?]], interpreter: Interpreter[F]): F[Unit] =
+    val recovery = new Recovery(self, interpreter)
+
+    effect.delay { bootMode = BootMode.Replaying } >>
+      recovery.seedSequencers() >>
+      recovery.boot(processes0) >>
+      effect.delay { bootMode = BootMode.Live } >>
+      Monad.sequence(getProcesses.map(process => sendStartEvent(process.ref))).void
 
   /** The snapshot manager, if snapshotting is enabled; used by [[io.parapet.core.Recovery]] to restore at boot. */
   private[parapet] def snapshots: Option[SnapshotManager[F]] = snapshotManager
@@ -261,14 +276,15 @@ object Context:
       journalStorage: Option[JournalStore[F]] = None,
       codecRegistry: EventCodecRegistry = EventCodecRegistry.empty
   )(using effect: Effect[F]): F[Context[F]] =
+    val codecs = EventCodecRegistry.withSystemCodecs(codecRegistry)
     for
       snapshots <- buildWithStorage(config.snapshot.enabled, snapshotStorage, "snapshotting")(
         SnapshotManager[F](_, Clock(), config.snapshot.queueCapacity)
       )
       recorder <- buildWithStorage(config.journal.enabled, journalStorage, "journal")(store =>
-        effect.pure(DeliveryRecorder.fresh(store, codecRegistry, config.journal))
+        effect.pure(DeliveryRecorder.fresh(store, codecs, config.journal))
       )
-    yield new Context[F](config, eventTransformers, snapshots, recorder, codecRegistry)
+    yield new Context[F](config, eventTransformers, snapshots, recorder, codecs)
 
   private def buildWithStorage[F[_], S, M](enabled: Boolean, storage: Option[S], name: String)(
       build: S => F[M]

--- a/parapet-core/src/main/scala/io/parapet/core/Context.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Context.scala
@@ -179,8 +179,7 @@ class Context[F[_]](
     }
 
   private def recordRegistration(parent: ProcessRef.Unknown, child: ProcessRef.Unknown): F[Unit] =
-    if replaying then
-      effect.raiseError(new IllegalStateException("registration recording is not allowed during replay"))
+    if replaying then effect.pure(())
     else
       recorder match
         case None    => effect.pure(())
@@ -219,13 +218,15 @@ class Context[F[_]](
 
   /** Restores and replays the application, then schedules [[Events.Start]] for the live phase. */
   private[parapet] def boot(processes0: List[Process[F, ?, ?]], interpreter: Interpreter[F]): F[Unit] =
-    if snapshotEnabled || journalEnabled then
-      val recovery = new Recovery(self, interpreter)
-      effect.delay { bootMode = BootMode.Replaying } >> 
-        recovery.seedSequencers() >>
-        recovery.boot(processes0) >>
-        effect.delay { bootMode = BootMode.Live } 
-    else effect.pure(()) >> Monad.sequence(getProcesses.map(process => sendStartEvent(process.ref))).void
+    val recovery = new Recovery(self, interpreter)
+    effect.delay {
+      bootMode = BootMode.Replaying
+    } >>
+      recovery.seedSequencers() >>
+      recovery.boot(processes0) >>
+      effect.delay {
+        bootMode = BootMode.Live
+      } >> Monad.sequence(getProcesses.map(process => sendStartEvent(process.ref))).void
 
   /** The snapshot manager, if snapshotting is enabled; used by [[io.parapet.core.Recovery]] to restore at boot. */
   private[parapet] def snapshots: Option[SnapshotManager[F]] = snapshotManager

--- a/parapet-core/src/main/scala/io/parapet/core/Context.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Context.scala
@@ -74,7 +74,7 @@ class Context[F[_]](
   /** The codec for `event`, or `None` when its type is not registered */
   def codecFor(event: Event): Option[EventCodec] = codecRegistry.codecFor(event)
 
-  /** The codec that recorded entries under `tag`, or `None` when the tag is unknown - used to decode on replay. */
+  /** The codec that recorded entries under `tag`, or `None` when the tag is unknown */
   def codecForTag(tag: String): Option[EventCodec] = codecRegistry.codecForTag(tag)
 
   private val bootModeRef = new AtomicReference[BootMode](BootMode.Live)
@@ -82,7 +82,7 @@ class Context[F[_]](
   /** Current boot mode; [[BootMode.Replaying]] while recovery re-folds recorded history, else [[BootMode.Live]]. */
   def bootMode: BootMode = bootModeRef.get
 
-  /** True while replaying recorded history - the interpreter suppresses outward effects. */
+  /** True while replaying recorded history */
   def replaying: Boolean = bootMode == BootMode.Replaying
 
   private[parapet] def bootMode_=(mode: BootMode): Unit = bootModeRef.set(mode)
@@ -97,7 +97,7 @@ class Context[F[_]](
   def stopJournal: F[Unit] =
     recorder.fold(effect.pure(()))(_.close())
 
-  /** Recorded deliveries with `seq > afterSeq` in ascending order, or empty when the journal is off. For replay. */
+  /** Recorded deliveries with `seq > afterSeq` in ascending order, or empty when the journal is off. */
   def readJournal(afterSeq: Long): F[Vector[journal.JournalEntry]] =
     recorder.fold(effect.pure(Vector.empty[journal.JournalEntry]))(_.read(afterSeq))
 
@@ -179,7 +179,8 @@ class Context[F[_]](
     }
 
   private def recordRegistration(parent: ProcessRef.Unknown, child: ProcessRef.Unknown): F[Unit] =
-    if replaying then effect.pure(())
+    if replaying then
+      effect.raiseError(new IllegalStateException("registration recording is not allowed during replay"))
     else
       recorder match
         case None    => effect.pure(())
@@ -192,7 +193,7 @@ class Context[F[_]](
   def child(parent: ProcessRef.Unknown): Vector[ProcessRef.Unknown] =
     graph.getOrDefault(parent, ListBuffer.empty).toVector
 
-  /** Registers a live child and schedules [[Events.Initialize]] followed by [[Events.Start]]. */
+  /** Registers a child and schedules [[Events.Initialize]] followed by [[Events.Start]]. */
   def registerAndStart(parent: ProcessRef.Unknown, process: Process[F, ?, ?]): F[SubmissionResult] =
     register(parent, process) >> sendLifecycleEvent(process.ref, Initialize) >> sendStartEvent(process.ref)
 
@@ -232,7 +233,7 @@ class Context[F[_]](
   /** Highest delivery `seq` recorded in the journal, or `None`; seeds the delivery counter at boot. */
   private[parapet] def journalMaxSeq: F[Option[Long]] = recorder.fold(effect.pure(Option.empty[Long]))(_.maxSeq)
 
-  /** Highest envelope id the journal refers to, or `None`; seeds the envelope-id counter at boot. */
+  /** Highest envelope id the journal refers to, or `None` */
   private[parapet] def journalMaxEnvelopeId: F[Option[Long]] =
     recorder.fold(effect.pure(Option.empty[Long]))(_.maxEnvelopeId)
 
@@ -383,7 +384,7 @@ object Context:
     val snapshotable: Boolean = process.isInstanceOf[snapshot.Snapshotable]
 
     /** The delivery `seq` this process was restored to at boot, or `0` if it started fresh. Replay skips entries with
-      * `seq <= restoredSeq` (already folded into the snapshot). Written on the boot thread before workers start.
+      * `seq <= restoredSeq` (already folded into the snapshot).
       */
     var restoredSeq: Long = 0L
 

--- a/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -3,6 +3,7 @@ package io.parapet.core
 import io.parapet.core.Context.ProcessState
 import io.parapet.core.Dsl.*
 import io.parapet.core.Scheduler.{Deliver, ProcessQueueIsFull}
+import io.parapet.core.exceptions.RecoveryContractViolation
 import io.parapet.effect.{Deferred, Effect}
 import io.parapet.effect.Monad.*
 import io.parapet.free.{FunctionK, ~>}
@@ -107,6 +108,9 @@ object DslInterpreter:
                 .asInstanceOf[DslF[F, Unit]]
                 .foldMap(interpret(sender, processState, scope))
 
+            case Fork(_) if recoveryRestricted(processState) =>
+              effect.raiseError(RecoveryContractViolation(processState.process.ref, "Fork"))
+
             case Fork(flow) =>
               effect
                 .start(
@@ -123,6 +127,9 @@ object DslInterpreter:
             case Eval(thunk) =>
               effect.delay(thunk())
 
+            case Suspend(_) if recoveryRestricted(processState) =>
+              effect.raiseError(RecoveryContractViolation(processState.process.ref, "Suspend"))
+
             case Suspend(thunk) =>
               effect.suspend(thunk())
 
@@ -133,6 +140,9 @@ object DslInterpreter:
                     .asInstanceOf[DslF[F, A]]
                     .foldMap(interpret(sender, processState, scope))
                 )
+
+            case Race(_, _) if recoveryRestricted(processState) =>
+              effect.raiseError(RecoveryContractViolation(processState.process.ref, "Race"))
 
             case Race(first, second) =>
               val first0  = first.asInstanceOf[DslF[F, Any]].foldMap(interpret(sender, processState, scope))
@@ -171,7 +181,9 @@ object DslInterpreter:
                 .asInstanceOf[DslF[F, A]]
                 .foldMap(interpret(sender, processState, scope))
                 .handleErrorWith { error =>
-                  onError(error).asInstanceOf[DslF[F, A]].foldMap(interpret(sender, processState, scope))
+                  error match
+                    case violation: RecoveryContractViolation => effect.raiseError(violation)
+                    case _ => onError(error).asInstanceOf[DslF[F, A]].foldMap(interpret(sender, processState, scope))
                 }
 
             case Halt(ref) =>
@@ -208,6 +220,9 @@ object DslInterpreter:
               body
                 .asInstanceOf[DslF[F, A]]
                 .foldMap(interpret(sender, processState, f(scope)))
+
+    private def recoveryRestricted(processState: ProcessState[F]): Boolean =
+      context.journalEnabled && !processState.process.isInstanceOf[ReplayBoundary]
 
     private def send(
         sender: ProcessRef.Unknown,

--- a/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -95,10 +95,12 @@ object DslInterpreter:
                 .foldMap(interpret(sender, processState, scope))
 
             case Forward(event, receivers) =>
-              receivers
-                .foldLeft(effect.pure(())) { (acc, receiver) =>
-                  acc >> send(sender, event, receiver, scope)
-                }
+              if context.replaying then effect.pure(())
+              else
+                receivers
+                  .foldLeft(effect.pure(())) { (acc, receiver) =>
+                    acc >> send(sender, event, receiver, scope)
+                  }
 
             case Par(flow) =>
               flow
@@ -156,8 +158,8 @@ object DslInterpreter:
               yield ().asInstanceOf[A]
 
             case Register(parent, process: Process[F, ?, ?] @unchecked) =>
-              // While replaying, register structurally only - Recovery drives restore + Restored for re-spawned
-              // children. A live spawn registers and starts.
+              // Recovery prepares structurally registered children at their registration marker. Live registration
+              // schedules Initialize followed by Start.
               if context.replaying then context.register(parent, process).void
               else context.registerAndStart(parent, process).void
 

--- a/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -77,8 +77,6 @@ object DslInterpreter:
               effect.pure(())
 
             case Send(event, senderOverride, receiver, receivers) =>
-              // While replaying, outward sends are suppressed: their recorded deliveries are re-injected by the driver,
-              // so re-emitting them here would double-deliver.
               if context.replaying then effect.pure(())
               else
                 val source = senderOverride.getOrElse(processState.process.ref)
@@ -121,7 +119,6 @@ object DslInterpreter:
                 .map(fiber => Fiber.RuntimeFiber(fiber).asInstanceOf[A])
 
             case delay: Delay[F] =>
-              // Logical time: while replaying, a delay is zero-duration - the timeout it gates is re-injected at its seq.
               if context.replaying then effect.pure(()) else effect.sleep(delay.duration)
 
             case Eval(thunk) =>
@@ -150,7 +147,6 @@ object DslInterpreter:
               effect.race(first0, second0).asInstanceOf[F[A]]
 
             case Offload(_) if context.replaying =>
-              // Replay does not re-run offloaded work; its effects (emitted events) are already in the journal.
               effect.pure(().asInstanceOf[A])
 
             case Offload(body) =>
@@ -168,8 +164,6 @@ object DslInterpreter:
               yield ().asInstanceOf[A]
 
             case Register(parent, process: Process[F, ?, ?] @unchecked) =>
-              // Recovery prepares structurally registered children at their registration marker. Live registration
-              // schedules Initialize followed by Start.
               if context.replaying then context.register(parent, process).void
               else context.registerAndStart(parent, process).void
 
@@ -180,10 +174,9 @@ object DslInterpreter:
               body()
                 .asInstanceOf[DslF[F, A]]
                 .foldMap(interpret(sender, processState, scope))
-                .handleErrorWith { error =>
-                  error match
-                    case violation: RecoveryContractViolation => effect.raiseError(violation)
-                    case _ => onError(error).asInstanceOf[DslF[F, A]].foldMap(interpret(sender, processState, scope))
+                .handleErrorWith {
+                  case violation: RecoveryContractViolation => effect.raiseError(violation)
+                  case error => onError(error).asInstanceOf[DslF[F, A]].foldMap(interpret(sender, processState, scope))
                 }
 
             case Halt(ref) =>

--- a/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/DslInterpreter.scala
@@ -76,13 +76,17 @@ object DslInterpreter:
               effect.pure(())
 
             case Send(event, senderOverride, receiver, receivers) =>
-              val source = senderOverride.getOrElse(processState.process.ref)
-              val first  = send(source, event, receiver, scope)
-              if receivers.nonEmpty then
-                first >> receivers.foldLeft(effect.pure(())) { (acc, next) =>
-                  acc >> send(source, event, next, scope)
-                }
-              else first
+              // While replaying, outward sends are suppressed: their recorded deliveries are re-injected by the driver,
+              // so re-emitting them here would double-deliver.
+              if context.replaying then effect.pure(())
+              else
+                val source = senderOverride.getOrElse(processState.process.ref)
+                val first  = send(source, event, receiver, scope)
+                if receivers.nonEmpty then
+                  first >> receivers.foldLeft(effect.pure(())) { (acc, next) =>
+                    acc >> send(source, event, next, scope)
+                  }
+                else first
 
             case WithSender(runWithSender) =>
               runWithSender
@@ -111,7 +115,8 @@ object DslInterpreter:
                 .map(fiber => Fiber.RuntimeFiber(fiber).asInstanceOf[A])
 
             case delay: Delay[F] =>
-              effect.sleep(delay.duration)
+              // Logical time: while replaying, a delay is zero-duration - the timeout it gates is re-injected at its seq.
+              if context.replaying then effect.pure(()) else effect.sleep(delay.duration)
 
             case Eval(thunk) =>
               effect.delay(thunk())
@@ -132,6 +137,10 @@ object DslInterpreter:
               val second0 = second.asInstanceOf[DslF[F, Any]].foldMap(interpret(sender, processState, scope))
               effect.race(first0, second0).asInstanceOf[F[A]]
 
+            case Offload(_) if context.replaying =>
+              // Replay does not re-run offloaded work; its effects (emitted events) are already in the journal.
+              effect.pure(().asInstanceOf[A])
+
             case Offload(body) =>
               for
                 done  <- Deferred[F, Either[Throwable, Unit]]()
@@ -147,7 +156,10 @@ object DslInterpreter:
               yield ().asInstanceOf[A]
 
             case Register(parent, process: Process[F, ?, ?] @unchecked) =>
-              context.registerAndStart(parent, process).void
+              // While replaying, register structurally only - Recovery drives restore + Restored for re-spawned
+              // children. A live spawn registers and starts.
+              if context.replaying then context.register(parent, process).void
+              else context.registerAndStart(parent, process).void
 
             case RaiseError(error) =>
               effect.raiseError(error)

--- a/parapet-core/src/main/scala/io/parapet/core/Events.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Events.scala
@@ -1,6 +1,6 @@
 package io.parapet.core
 
-import io.parapet.{Envelope, Event}
+import io.parapet.{Envelope, Event, ProcessRef}
 
 /** System-defined [[Event]]s emitted by the parapet runtime.
   *
@@ -12,14 +12,23 @@ object Events {
   /** Marker trait for runtime-issued lifecycle events. Not generally extended by user code. */
   sealed trait SystemEvent extends Event
 
-  /** First event delivered to every process after registration. Use to perform initial setup such as registering child
-    * processes or sending a "ready" notification.
+  /** Prepares a fresh process instance before it receives replayed or live domain events. */
+  case object Initialize extends SystemEvent
+
+  /** Signals that a process may begin live operation. During recovery it is delivered after snapshot restoration and
+    * journal replay have completed.
     */
   case object Start extends SystemEvent
 
-  /** Delivered instead of [[Start]] when a process was restored from a snapshot at boot.
+  /** Delivered after a snapshot has restored a process's state and before journal entries are replayed. [[Start]]
+    * follows after replay completes.
     */
   case object Restored extends SystemEvent
+
+  /** Marks the point at which `child` was registered by the receiving parent. Used by recovery to synchronize replay of
+    * a dynamic process tree.
+    */
+  final case class Registered(child: ProcessRef.Unknown) extends SystemEvent
 
   /** Sent during graceful shutdown. The process should wrap up in-flight work and release resources; child processes
     * are stopped first by the runtime.

--- a/parapet-core/src/main/scala/io/parapet/core/Recovery.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Recovery.scala
@@ -1,0 +1,152 @@
+package io.parapet.core
+
+import com.typesafe.scalalogging.Logger
+import io.parapet.core.DslInterpreter.Interpreter
+import io.parapet.core.journal.JournalEntry
+import io.parapet.core.snapshot.{Snapshot, Snapshotable}
+import io.parapet.effect.Effect
+import io.parapet.effect.Monad.*
+import io.parapet.{Envelope, Event, ProcessRef, Scope}
+import org.slf4j.LoggerFactory
+
+import scala.util.{Failure, Success}
+
+/** Owns application boot: registers the initial processes, restores each from its latest snapshot, then re-folds the
+  * recorded journal onto them so every process catches up from its snapshot boundary to the last recorded delivery.
+  *
+  * The re-fold runs with the runtime in [[BootMode.Replaying]], so the interpreter suppresses sends and effects. Unlike
+  * live delivery it drives the handler directly - it does not record the delivery, stamp a new `seq`, or fire snapshot
+  * triggers, so it never re-enters the recording seam. Restore uses the [[Context]] registration hook (shared with
+  * dynamic re-spawn); [[Recovery]] owns the ordering.
+  */
+final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(using effect: Effect[F]):
+
+  private val logger = Logger(LoggerFactory.getLogger(classOf[Recovery[?]]))
+
+  /** Advances the delivery-sequence and envelope-id counters past what the journal already holds, so a restart
+    * continues rather than reissuing positions. Call before any envelope is created (i.e. before binding the
+    * scheduler).
+    */
+  def seedSequencers(): F[Unit] =
+    for
+      maxSeq <- context.journalMaxSeq
+      maxId  <- context.journalMaxEnvelopeId
+      _      <- effect.delay {
+        maxSeq.foreach(context.continueSeqAfter)
+        maxId.foreach(Envelope.continueIdAfter)
+      }
+    yield ()
+
+  private val recovered = scala.collection.mutable.Set.empty[ProcessRef.Unknown]
+
+  /** Boots `processes`: register and recover each - restore + [[io.parapet.core.Events.Restored]], recursing into the
+    * children each `Restored` handler re-spawns - then re-fold the recorded journal onto the whole tree. Runs under
+    * [[BootMode.Replaying]] throughout and returns to [[BootMode.Live]] before the caller starts the scheduler.
+    */
+  def boot(processes: List[Process[F, ?, ?]]): F[Unit] =
+    effect.delay { context.bootMode = BootMode.Replaying } >>
+      processes.foldLeft(effect.pure(()))((acc, p) => acc >> context.register(ProcessRef.SystemRef, p).void) >>
+      processes.foldLeft(effect.pure(()))((acc, p) => acc >> recover(p)) >>
+      reFold() >>
+      effect.delay { context.bootMode = BootMode.Live }
+
+  /** Recovers one process and, when it was restored, the subtree it re-spawns.
+    *
+    * Restores state from the latest snapshot; a restored process is delivered [[io.parapet.core.Events.Restored]]
+    * synchronously so its handler re-spawns children *before* the re-fold, then each child registered under it is
+    * recovered in turn. A process with no snapshot is queued an [[io.parapet.core.Events.Start]] instead, delivered
+    * live once the scheduler starts so its initial work is not suppressed. `recovered` guards against re-processing.
+    */
+  private def recover(process: Process[F, ?, ?]): F[Unit] =
+    if recovered.contains(process.ref) then effect.pure(())
+    else
+      recovered.add(process.ref)
+      restoreState(process).flatMap {
+        case true  => deliverLifecycle(process.ref, Events.Restored) >> recoverChildren(process.ref)
+        case false => context.sendStartEvent(process.ref).void
+      }
+
+  /** Restores `process` from its latest snapshot and records its restored `seq`, without any lifecycle event. Returns
+    * `true` if a snapshot was found and applied, `false` if the process started fresh.
+    */
+  private def restoreState(process: Process[F, ?, ?]): F[Boolean] =
+    val ref: ProcessRef.Unknown = process.ref
+    process match
+      case snapshotable: Snapshotable =>
+        context.snapshots.fold(effect.pure(Option.empty[Snapshot]))(_.restoreLatest(ref, snapshotable)).flatMap {
+          case Some(restored) =>
+            effect
+              .delay {
+                context.continueSeqAfter(restored.metadata.seq)
+                context.getProcessState(ref).foreach(_.restoredSeq = restored.metadata.seq)
+              }
+              .map(_ => true)
+          case None => effect.pure(false)
+        }
+      case _ => effect.pure(false)
+
+  /** Restores `process`'s state once, if it hasn't already been recovered - for a child that first appears mid-re-fold
+    * (created by a parent's replayed handler) so the `seq <= restoredSeq` filter can skip what its snapshot already
+    * holds.
+    */
+  private def ensureRestored(process: Process[F, ?, ?]): F[Unit] =
+    if recovered.contains(process.ref) then effect.pure(())
+    else
+      recovered.add(process.ref)
+      restoreState(process).void
+
+  /** Recovers every child the just-restored `parent` registered while handling [[io.parapet.core.Events.Restored]]. */
+  private def recoverChildren(parent: ProcessRef.Unknown): F[Unit] =
+    context.child(parent).foldLeft(effect.pure(())) { (acc, childRef) =>
+      acc >> context.getProcessState(childRef).fold(effect.pure(()))(ps => recover(ps.process))
+    }
+
+  /** Delivers a lifecycle event to `ref` synchronously through the interpreter (not via the scheduler), so its handler
+    * runs now. Under [[BootMode.Replaying]] its sends are suppressed, but `register` (child re-spawn) still runs.
+    */
+  private def deliverLifecycle(ref: ProcessRef.Unknown, event: Event): F[Unit] =
+    context.getProcessState(ref) match
+      case None     => effect.raiseError[Unit](new IllegalStateException(s"recovery: no process for $ref"))
+      case Some(ps) =>
+        effect.suspend(ps.process(event).foldMap(interpreter.interpret(ProcessRef.SystemRef, ps, Scope.empty)).void)
+
+  /** Re-folds the recorded history onto the registered processes: each entry replayed to its receiver in `seq` order,
+    * skipped when already in the receiver's snapshot (`seq <= restoredSeq`) or the receiver does not exist.
+    */
+  private def reFold(): F[Unit] =
+    context.readJournal(0L).flatMap { entries =>
+      entries.foldLeft(effect.pure(()))((acc, entry) => acc >> reFoldEntry(entry))
+    }
+
+  private def reFoldEntry(entry: JournalEntry): F[Unit] =
+    context.getProcessState(entry.receiver) match
+      case Some(ps) =>
+        // A child first seen here (created by a parent's replayed handler) is restored from its snapshot before the
+        // filter, so entries already folded into that snapshot are skipped rather than re-applied from scratch.
+        ensureRestored(ps.process).flatMap { _ =>
+          if entry.seq > ps.restoredSeq then replayDeliver(entry) else effect.pure(())
+        }
+      case None =>
+        effect.delay(logger.warn(s"replay: no process for receiver ${entry.receiver} at seq ${entry.seq}; skipping"))
+
+  /** Re-delivers one recorded entry to its receiver: decode the event, then run the receiver's handler through the
+    * interpreter under the entry's causal scope. Fails loud if the receiver does not exist or its codec is unknown.
+    */
+  def replayDeliver(entry: JournalEntry): F[Unit] =
+    context.getProcessState(entry.receiver) match
+      case None =>
+        effect.raiseError[Unit](new IllegalStateException(s"replay: no process for receiver ${entry.receiver}"))
+      case Some(ps) =>
+        context.codecForTag(entry.tag) match
+          case None =>
+            effect.raiseError[Unit](new IllegalStateException(s"replay: no codec for tag '${entry.tag}'"))
+          case Some(codec) =>
+            codec.decode(entry.schemaVersion, entry.event) match
+              case Failure(error) => effect.raiseError[Unit](error)
+              case Success(event) =>
+                val scope = Scope.empty.put(Scope.Cause, entry.id)
+                effect.suspend(ps.process(event).foldMap(interpreter.interpret(entry.sender, ps, scope)).void)
+
+  /** Folds a receiver's recorded deliveries in `seq` order (parallelism across receivers is added later). */
+  def replay(entries: Vector[JournalEntry]): F[Unit] =
+    entries.foldLeft(effect.pure(()))((acc, entry) => acc >> replayDeliver(entry))

--- a/parapet-core/src/main/scala/io/parapet/core/Recovery.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Recovery.scala
@@ -41,6 +41,8 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
       replay() >>
       recoverPending()
 
+  // ======================= RECOVER =======================  //
+
   /** Restores or initializes one process, then recovers the children it registered. */
   private def recover(process: Process[F, ?, ?]): F[Unit] =
     if recovered.contains(process.ref) then effect.pure(())
@@ -51,15 +53,21 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
         case false => deliverLifecycle(process.ref, Initialize)
       } >> recoverChildren(process.ref)
 
+  private def recover(ref: ProcessRef.Unknown): F[Unit] =
+    context.getProcessState(ref) match
+      case Some(state) => recover(state.process)
+      case None        => effect.raiseError(new IllegalStateException(s"process state doesn't exist. ref=$ref"))
+
   /** Restores `process` from its latest snapshot and records its replay boundary. */
   private def restoreState(process: Process[F, ?, ?]): F[Boolean] =
     val ref: ProcessRef.Unknown = process.ref
     process match
       case snapshotable: Snapshotable =>
-        context.snapshots.fold(effect.pure(Option.empty[Snapshot]))(_.restoreLatest(ref, snapshotable)).flatMap {
+        context.snapshotManager.fold(effect.pure(Option.empty[Snapshot]))(_.restoreLatest(ref, snapshotable)).flatMap {
           case Some(restored) =>
             effect
               .delay {
+                // in case if journal is not enabled, we need to update seq from snap
                 context.continueSeqAfter(restored.metadata.seq)
                 context.getProcessState(ref).foreach(s => updateProcessSeq(ref, restored.metadata.seq))
               }
@@ -70,7 +78,11 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
 
   private def recoverChildren(parent: ProcessRef.Unknown): F[Unit] =
     context.child(parent).foldLeft(effect.pure(())) { (acc, childRef) =>
-      acc >> context.getProcessState(childRef).fold(effect.pure(()))(state => recover(state.process))
+      acc >> context
+        .getProcessState(childRef)
+        .fold(effect.raiseError(new IllegalStateException(s"no state for child=$childRef")))(state =>
+          recover(state.process)
+        )
     }
 
   private def recoverPending(): F[Unit] =
@@ -95,6 +107,8 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
             )
         }
 
+  // ======================= REPLAY ======================= //
+
   private def replay(): F[Unit] =
     context.readJournal(0L).flatMap { entries =>
       entries.foldLeft(effect.pure(()))((acc, entry) => acc >> replay(entry))
@@ -111,7 +125,7 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
       case Some(state) =>
         if entry.seq > processSeq(state.process.ref)
         then replayDeliver(entry)
-        else effect.delay(logger.warn(s"replay ${entry.seq} <= ${processSeq(state.process.ref)}"))
+        else effect.delay(logger.warn(s"replay entry.seq=${entry.seq} <= process.seq${processSeq(state.process.ref)}"))
       case None =>
         effect.raiseError(
           new IllegalStateException(s"replay: no process for receiver ${entry.receiver} at seq ${entry.seq}")
@@ -120,35 +134,18 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
   /** Re-delivers one recorded entry without applying snapshot-boundary filtering. */
   private def replayDeliver(entry: JournalEntry): F[Unit] =
     context.getProcessState(entry.receiver) match
-      case None => effect.raiseError(new IllegalStateException(s"replay: no process for receiver ${entry.receiver}"))
+      case None        => effect.raiseError(new IllegalStateException(s"replay: no process for ref=${entry.receiver}"))
       case Some(state) =>
         context.codecForTag(entry.tag) match
           case None        => effect.raiseError(new IllegalStateException(s"replay: no codec for tag '${entry.tag}'"))
           case Some(codec) =>
             codec.decode(entry.schemaVersion, entry.event) match
               case Failure(error)                                           => effect.raiseError(error)
-              case Success(Registered(child))                               => recoverRegistered(entry, child)
+              case Success(Registered(child))                               => recover(child)
               case Success(_) if state.process.isInstanceOf[ReplayBoundary] => effect.pure(())
               case Success(event)                                           =>
                 val scope = Scope.empty.put(Scope.Cause, entry.id)
                 effect.suspend(state.process(event).foldMap(interpreter.interpret(entry.sender, state, scope)).void)
-
-  private def recoverRegistered(entry: JournalEntry, child: ProcessRef.Unknown): F[Unit] =
-    if entry.sender != ProcessRef.SystemRef then
-      effect.raiseError(
-        new IllegalStateException(s"replay: registration marker at seq ${entry.seq} has sender ${entry.sender}")
-      )
-    else if !context.child(entry.receiver).contains(child) then
-      effect.raiseError(
-        new IllegalStateException(
-          s"replay: parent ${entry.receiver} did not recreate child $child before registration marker ${entry.seq}"
-        )
-      )
-    else
-      context.getProcessState(child) match
-        case Some(state) => recover(state.process)
-        case None        =>
-          effect.raiseError(new IllegalStateException(s"replay: registered child $child does not exist"))
 
   private def processSeq(ref: ProcessRef.Unknown): Long = processSeqTracker.getOrElse(ref, 0L)
 

--- a/parapet-core/src/main/scala/io/parapet/core/Recovery.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Recovery.scala
@@ -7,13 +7,19 @@ import io.parapet.core.snapshot.{Snapshot, Snapshotable}
 import io.parapet.effect.Effect
 import io.parapet.effect.Monad.*
 import io.parapet.{Envelope, Event, ProcessRef, Scope}
+import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Success}
 
 /** Restores process state and replays recorded deliveries during application boot. */
 final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(using effect: Effect[F]):
 
+  private val logger = LoggerFactory.getLogger(classOf[Recovery[_]])
+
   private val recovered = scala.collection.mutable.Set.empty[ProcessRef.Unknown]
+
+  // tracks seq per process
+  private val processSeqTracker = scala.collection.mutable.Map.empty[ProcessRef.Unknown, Long]
 
   /** Advances the delivery-sequence and envelope-id counters past what the journal already holds. */
   def seedSequencers(): F[Unit] =
@@ -55,7 +61,7 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
             effect
               .delay {
                 context.continueSeqAfter(restored.metadata.seq)
-                context.getProcessState(ref).foreach(_.restoredSeq = restored.metadata.seq)
+                context.getProcessState(ref).foreach(s => updateProcessSeq(ref, restored.metadata.seq))
               }
               .map(_ => true)
           case None => effect.pure(false)
@@ -102,8 +108,11 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
             s"replay: process ${entry.receiver} received entry ${entry.seq} before recovery"
           )
         )
-      case Some(state) => if entry.seq > state.restoredSeq then replayDeliver(entry) else effect.pure(())
-      case None        =>
+      case Some(state) =>
+        if entry.seq > processSeq(state.process.ref)
+        then replayDeliver(entry)
+        else effect.delay(logger.warn(s"replay ${entry.seq} <= ${processSeq(state.process.ref)}"))
+      case None =>
         effect.raiseError(
           new IllegalStateException(s"replay: no process for receiver ${entry.receiver} at seq ${entry.seq}")
         )
@@ -140,3 +149,11 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
         case Some(state) => recover(state.process)
         case None        =>
           effect.raiseError(new IllegalStateException(s"replay: registered child $child does not exist"))
+
+  private def processSeq(ref: ProcessRef.Unknown): Long = processSeqTracker.getOrElse(ref, 0L)
+
+  private def updateProcessSeq(ref: ProcessRef.Unknown, seq: Long): Unit =
+    processSeqTracker.updateWith(ref) {
+      case Some(value) => if seq < value then throw new IllegalStateException(s"seq=$seq < $value") else Some(seq)
+      case None        => Some(seq)
+    }

--- a/parapet-core/src/main/scala/io/parapet/core/Recovery.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Recovery.scala
@@ -117,9 +117,10 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
           case None        => effect.raiseError(new IllegalStateException(s"replay: no codec for tag '${entry.tag}'"))
           case Some(codec) =>
             codec.decode(entry.schemaVersion, entry.event) match
-              case Failure(error)             => effect.raiseError(error)
-              case Success(Registered(child)) => recoverRegistered(entry, child)
-              case Success(event)             =>
+              case Failure(error)                                           => effect.raiseError(error)
+              case Success(Registered(child))                               => recoverRegistered(entry, child)
+              case Success(_) if state.process.isInstanceOf[ReplayBoundary] => effect.pure(())
+              case Success(event)                                           =>
                 val scope = Scope.empty.put(Scope.Cause, entry.id)
                 effect.suspend(state.process(event).foldMap(interpreter.interpret(entry.sender, state, scope)).void)
 

--- a/parapet-core/src/main/scala/io/parapet/core/Recovery.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Recovery.scala
@@ -1,32 +1,21 @@
 package io.parapet.core
 
-import com.typesafe.scalalogging.Logger
 import io.parapet.core.DslInterpreter.Interpreter
+import io.parapet.core.Events.{Initialize, Registered, Restored}
 import io.parapet.core.journal.JournalEntry
 import io.parapet.core.snapshot.{Snapshot, Snapshotable}
 import io.parapet.effect.Effect
 import io.parapet.effect.Monad.*
 import io.parapet.{Envelope, Event, ProcessRef, Scope}
-import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Success}
 
-/** Owns application boot: registers the initial processes, restores each from its latest snapshot, then re-folds the
-  * recorded journal onto them so every process catches up from its snapshot boundary to the last recorded delivery.
-  *
-  * The re-fold runs with the runtime in [[BootMode.Replaying]], so the interpreter suppresses sends and effects. Unlike
-  * live delivery it drives the handler directly - it does not record the delivery, stamp a new `seq`, or fire snapshot
-  * triggers, so it never re-enters the recording seam. Restore uses the [[Context]] registration hook (shared with
-  * dynamic re-spawn); [[Recovery]] owns the ordering.
-  */
+/** Restores process state and replays recorded deliveries during application boot. */
 final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(using effect: Effect[F]):
 
-  private val logger = Logger(LoggerFactory.getLogger(classOf[Recovery[?]]))
+  private val recovered = scala.collection.mutable.Set.empty[ProcessRef.Unknown]
 
-  /** Advances the delivery-sequence and envelope-id counters past what the journal already holds, so a restart
-    * continues rather than reissuing positions. Call before any envelope is created (i.e. before binding the
-    * scheduler).
-    */
+  /** Advances the delivery-sequence and envelope-id counters past what the journal already holds. */
   def seedSequencers(): F[Unit] =
     for
       maxSeq <- context.journalMaxSeq
@@ -37,38 +26,26 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
       }
     yield ()
 
-  private val recovered = scala.collection.mutable.Set.empty[ProcessRef.Unknown]
-
-  /** Boots `processes`: register and recover each - restore + [[io.parapet.core.Events.Restored]], recursing into the
-    * children each `Restored` handler re-spawns - then re-fold the recorded journal onto the whole tree. Runs under
-    * [[BootMode.Replaying]] throughout and returns to [[BootMode.Live]] before the caller starts the scheduler.
-    */
+  /** Registers and recovers the initial processes, then replays the journal. */
   def boot(processes: List[Process[F, ?, ?]]): F[Unit] =
-    effect.delay { context.bootMode = BootMode.Replaying } >>
-      processes.foldLeft(effect.pure(()))((acc, p) => acc >> context.register(ProcessRef.SystemRef, p).void) >>
-      processes.foldLeft(effect.pure(()))((acc, p) => acc >> recover(p)) >>
-      reFold() >>
-      effect.delay { context.bootMode = BootMode.Live }
+    processes.foldLeft(effect.pure(()))((acc, process) =>
+      acc >> context.register(ProcessRef.SystemRef, process).void
+    ) >>
+      processes.foldLeft(effect.pure(()))((acc, process) => acc >> recover(process)) >>
+      replay() >>
+      recoverPending()
 
-  /** Recovers one process and, when it was restored, the subtree it re-spawns.
-    *
-    * Restores state from the latest snapshot; a restored process is delivered [[io.parapet.core.Events.Restored]]
-    * synchronously so its handler re-spawns children *before* the re-fold, then each child registered under it is
-    * recovered in turn. A process with no snapshot is queued an [[io.parapet.core.Events.Start]] instead, delivered
-    * live once the scheduler starts so its initial work is not suppressed. `recovered` guards against re-processing.
-    */
+  /** Restores or initializes one process, then recovers the children it registered. */
   private def recover(process: Process[F, ?, ?]): F[Unit] =
     if recovered.contains(process.ref) then effect.pure(())
     else
       recovered.add(process.ref)
       restoreState(process).flatMap {
-        case true  => deliverLifecycle(process.ref, Events.Restored) >> recoverChildren(process.ref)
-        case false => context.sendStartEvent(process.ref).void
-      }
+        case true  => deliverLifecycle(process.ref, Restored)
+        case false => deliverLifecycle(process.ref, Initialize)
+      } >> recoverChildren(process.ref)
 
-  /** Restores `process` from its latest snapshot and records its restored `seq`, without any lifecycle event. Returns
-    * `true` if a snapshot was found and applied, `false` if the process started fresh.
-    */
+  /** Restores `process` from its latest snapshot and records its replay boundary. */
   private def restoreState(process: Process[F, ?, ?]): F[Boolean] =
     val ref: ProcessRef.Unknown = process.ref
     process match
@@ -85,68 +62,80 @@ final class Recovery[F[_]](context: Context[F], interpreter: Interpreter[F])(usi
         }
       case _ => effect.pure(false)
 
-  /** Restores `process`'s state once, if it hasn't already been recovered - for a child that first appears mid-re-fold
-    * (created by a parent's replayed handler) so the `seq <= restoredSeq` filter can skip what its snapshot already
-    * holds.
-    */
-  private def ensureRestored(process: Process[F, ?, ?]): F[Unit] =
-    if recovered.contains(process.ref) then effect.pure(())
-    else
-      recovered.add(process.ref)
-      restoreState(process).void
-
-  /** Recovers every child the just-restored `parent` registered while handling [[io.parapet.core.Events.Restored]]. */
   private def recoverChildren(parent: ProcessRef.Unknown): F[Unit] =
     context.child(parent).foldLeft(effect.pure(())) { (acc, childRef) =>
-      acc >> context.getProcessState(childRef).fold(effect.pure(()))(ps => recover(ps.process))
+      acc >> context.getProcessState(childRef).fold(effect.pure(()))(state => recover(state.process))
     }
 
-  /** Delivers a lifecycle event to `ref` synchronously through the interpreter (not via the scheduler), so its handler
-    * runs now. Under [[BootMode.Replaying]] its sends are suppressed, but `register` (child re-spawn) still runs.
-    */
+  private def recoverPending(): F[Unit] =
+    val pending = context.getProcesses.filterNot(process => recoveredOrRuntime(process.ref))
+    if pending.isEmpty then effect.pure(())
+    else
+      pending.foldLeft(effect.pure(()))((acc, process) => acc >> recover(process)) >>
+        recoverPending()
+
+  private def recoveredOrRuntime(ref: ProcessRef.Unknown): Boolean =
+    recovered.contains(ref) || ProcessRef.RuntimeProcessRefs.contains(ref)
+
   private def deliverLifecycle(ref: ProcessRef.Unknown, event: Event): F[Unit] =
     context.getProcessState(ref) match
-      case None     => effect.raiseError[Unit](new IllegalStateException(s"recovery: no process for $ref"))
-      case Some(ps) =>
-        effect.suspend(ps.process(event).foldMap(interpreter.interpret(ProcessRef.SystemRef, ps, Scope.empty)).void)
+      case None        => effect.raiseError(new IllegalStateException(s"recovery: no process for $ref"))
+      case Some(state) =>
+        effect.delay(state.process.canHandle(event)).flatMap {
+          case false => effect.pure(())
+          case true  =>
+            effect.suspend(
+              state.process(event).foldMap(interpreter.interpret(ProcessRef.SystemRef, state, Scope.empty)).void
+            )
+        }
 
-  /** Re-folds the recorded history onto the registered processes: each entry replayed to its receiver in `seq` order,
-    * skipped when already in the receiver's snapshot (`seq <= restoredSeq`) or the receiver does not exist.
-    */
-  private def reFold(): F[Unit] =
+  private def replay(): F[Unit] =
     context.readJournal(0L).flatMap { entries =>
-      entries.foldLeft(effect.pure(()))((acc, entry) => acc >> reFoldEntry(entry))
+      entries.foldLeft(effect.pure(()))((acc, entry) => acc >> replay(entry))
     }
 
-  private def reFoldEntry(entry: JournalEntry): F[Unit] =
+  private def replay(entry: JournalEntry): F[Unit] =
     context.getProcessState(entry.receiver) match
-      case Some(ps) =>
-        // A child first seen here (created by a parent's replayed handler) is restored from its snapshot before the
-        // filter, so entries already folded into that snapshot are skipped rather than re-applied from scratch.
-        ensureRestored(ps.process).flatMap { _ =>
-          if entry.seq > ps.restoredSeq then replayDeliver(entry) else effect.pure(())
-        }
-      case None =>
-        effect.delay(logger.warn(s"replay: no process for receiver ${entry.receiver} at seq ${entry.seq}; skipping"))
+      case Some(_) if !recoveredOrRuntime(entry.receiver) =>
+        effect.raiseError(
+          new IllegalStateException(
+            s"replay: process ${entry.receiver} received entry ${entry.seq} before recovery"
+          )
+        )
+      case Some(state) => if entry.seq > state.restoredSeq then replayDeliver(entry) else effect.pure(())
+      case None        =>
+        effect.raiseError(
+          new IllegalStateException(s"replay: no process for receiver ${entry.receiver} at seq ${entry.seq}")
+        )
 
-  /** Re-delivers one recorded entry to its receiver: decode the event, then run the receiver's handler through the
-    * interpreter under the entry's causal scope. Fails loud if the receiver does not exist or its codec is unknown.
-    */
-  def replayDeliver(entry: JournalEntry): F[Unit] =
+  /** Re-delivers one recorded entry without applying snapshot-boundary filtering. */
+  private def replayDeliver(entry: JournalEntry): F[Unit] =
     context.getProcessState(entry.receiver) match
-      case None =>
-        effect.raiseError[Unit](new IllegalStateException(s"replay: no process for receiver ${entry.receiver}"))
-      case Some(ps) =>
+      case None => effect.raiseError(new IllegalStateException(s"replay: no process for receiver ${entry.receiver}"))
+      case Some(state) =>
         context.codecForTag(entry.tag) match
-          case None =>
-            effect.raiseError[Unit](new IllegalStateException(s"replay: no codec for tag '${entry.tag}'"))
+          case None        => effect.raiseError(new IllegalStateException(s"replay: no codec for tag '${entry.tag}'"))
           case Some(codec) =>
             codec.decode(entry.schemaVersion, entry.event) match
-              case Failure(error) => effect.raiseError[Unit](error)
-              case Success(event) =>
+              case Failure(error)             => effect.raiseError(error)
+              case Success(Registered(child)) => recoverRegistered(entry, child)
+              case Success(event)             =>
                 val scope = Scope.empty.put(Scope.Cause, entry.id)
-                effect.suspend(ps.process(event).foldMap(interpreter.interpret(entry.sender, ps, scope)).void)
+                effect.suspend(state.process(event).foldMap(interpreter.interpret(entry.sender, state, scope)).void)
 
-  /** Folds a receiver's recorded deliveries in `seq` order (parallelism across receivers is added later). */
-  def replay(entries: Vector[JournalEntry]): F[Unit] =
-    entries.foldLeft(effect.pure(()))((acc, entry) => acc >> replayDeliver(entry))
+  private def recoverRegistered(entry: JournalEntry, child: ProcessRef.Unknown): F[Unit] =
+    if entry.sender != ProcessRef.SystemRef then
+      effect.raiseError(
+        new IllegalStateException(s"replay: registration marker at seq ${entry.seq} has sender ${entry.sender}")
+      )
+    else if !context.child(entry.receiver).contains(child) then
+      effect.raiseError(
+        new IllegalStateException(
+          s"replay: parent ${entry.receiver} did not recreate child $child before registration marker ${entry.seq}"
+        )
+      )
+    else
+      context.getProcessState(child) match
+        case Some(state) => recover(state.process)
+        case None        =>
+          effect.raiseError(new IllegalStateException(s"replay: registered child $child does not exist"))

--- a/parapet-core/src/main/scala/io/parapet/core/ReplayBoundary.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/ReplayBoundary.scala
@@ -1,0 +1,8 @@
+package io.parapet.core
+
+/** Marks a process whose recorded domain deliveries are not re-executed during recovery.
+  *
+  * Its snapshot and lifecycle are still restored normally. It must recreate children from [[Events.Initialize]] or
+  * [[Events.Restored]]; external work resumes after [[Events.Start]].
+  */
+trait ReplayBoundary

--- a/parapet-core/src/main/scala/io/parapet/core/Scheduler.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Scheduler.scala
@@ -487,7 +487,7 @@ object Scheduler:
       private def journalAdmit(envelope: Envelope): F[Long] =
         context.admit(JournalDraft(envelope.id, envelope.sender, envelope.receiver, envelope.cause, envelope.event))
 
-      /** True for everything except runtime lifecycle events, which are re-synthesized at boot rather than replayed. */
+      /** Runtime events are not recorded at the delivery seam. */
       private def journaled(event: Event): Boolean =
         !event.isInstanceOf[SystemEvent]
 
@@ -577,7 +577,7 @@ object Scheduler:
                       val whenUndefined: F[Unit] = event match
                         case failure: Failure =>
                           sendToDeadLetter(DeadLetter(failure), context, interpreter, deliveryScope)
-                        case Start =>
+                        case Initialize | Restored | Start =>
                           effect.pure(())
                         case _ =>
                           send(
@@ -589,8 +589,8 @@ object Scheduler:
                           )
 
                       val logMessage = event match
-                        case Start | Stop => effect.pure(())
-                        case _            => logger.warn(errorMessage)
+                        case Initialize | Restored | Start | Stop => effect.pure(())
+                        case _                                    => logger.warn(errorMessage)
 
                       logMessage >> whenUndefined
 

--- a/parapet-core/src/main/scala/io/parapet/core/Scheduler.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/Scheduler.scala
@@ -661,7 +661,10 @@ object Scheduler:
           processState: ProcessState[F],
           errorHandler: Throwable => F[Unit]
       ): F[Unit] =
-        logger.debug(s"worker[$name]::runEffect. envelope: $envelope") >> effect0.handleErrorWith(errorHandler)
+        logger.debug(s"worker[$name]::runEffect. envelope: $envelope") >> effect0.handleErrorWith {
+          case violation: RecoveryContractViolation => effect.raiseError(violation)
+          case error                                => errorHandler(error)
+        }
 
       private def createNotifySignal(ref: ProcessRef.Unknown): Signal =
         Signal(Envelope(ProcessRef.SchedulerRef, NotifyEvent, ref))

--- a/parapet-core/src/main/scala/io/parapet/core/exceptions/package.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/exceptions/package.scala
@@ -36,6 +36,12 @@ package object exceptions {
   /** Raised when an event arrives at a process whose `handle` is not defined for it. */
   case class EventMatchException(message: String) extends RuntimeException(message)
 
+  /** Raised when a process that participates in recovery executes an operation reserved for a replay boundary. */
+  final case class RecoveryContractViolation(process: ProcessRef.Unknown, operation: String)
+      extends RuntimeException(
+        s"process '$process' cannot execute $operation while recovery is enabled; move it behind ReplayBoundary"
+      )
+
   /** Raised when a process is used before its [[io.parapet.core.Process.init]] hook ran. */
   case class UninitializedProcessException(message: String) extends RuntimeException(message)
 

--- a/parapet-core/src/main/scala/io/parapet/core/journal/DeliveryRecorder.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/journal/DeliveryRecorder.scala
@@ -147,6 +147,9 @@ final class DeliveryRecorder[F[_]] private (
   def continueAfter(after: Long): Unit =
     lock.synchronized { if after > seq then seq = after }
 
+  /** All durably recorded entries with `seq > afterSeq`, in ascending `seq` order. For replay. */
+  def read(afterSeq: Long): F[Vector[JournalEntry]] = store.read(afterSeq)
+
   /** The highest `seq` durably recorded, or `None` when the journal is empty. */
   def maxSeq: F[Option[Long]] = store.maxSeq
 

--- a/parapet-core/src/main/scala/io/parapet/core/journal/EventCodecRegistry.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/journal/EventCodecRegistry.scala
@@ -3,6 +3,7 @@ package io.parapet.core.journal
 import io.parapet.Event
 import io.parapet.core.Events
 import io.parapet.core.journal.EventCodec.Tag
+import scala.collection.mutable
 
 /** Resolves the [[EventCodec]].
   *
@@ -23,25 +24,27 @@ final class EventCodecRegistry private (
 
 object EventCodecRegistry:
 
-  private[core] def withSystemCodecs(registry: EventCodecRegistry): EventCodecRegistry =
-    val systemClass = classOf[Events.Registered]
-    require(!registry.byClass.contains(systemClass), s"event ${systemClass.getName} already has a codec")
-    require(!registry.byTag.contains(RegisteredEventCodec.tag), s"tag '${RegisteredEventCodec.tag}' is already claimed")
-    new EventCodecRegistry(
-      registry.byClass.updated(systemClass, RegisteredEventCodec),
-      registry.byTag.updated(RegisteredEventCodec.tag, RegisteredEventCodec)
-    )
+  private[core] val systemCodecs = Map[Class[?], EventCodec](
+    classOf[Events.Registered] -> RegisteredEventCodec
+  )
 
   /** Builds a registry, rejecting a class or a tag that is claimed more than once. */
   def apply(bindings: (Class[?], EventCodec)*): EventCodecRegistry =
-    val byClass = bindings.foldLeft(Map.empty[Class[?], EventCodec]) { case (acc, (cls, codec)) =>
-      require(!acc.contains(cls), s"event ${cls.getName} already has a codec")
-      acc.updated(cls, codec)
-    }
-    val byTag = bindings.foldLeft(Map.empty[Tag, EventCodec]) { case (acc, (_, codec)) =>
-      require(!acc.contains(codec.tag), s"tag '${codec.tag}' is claimed by more than one codec")
-      acc.updated(codec.tag, codec)
-    }
-    new EventCodecRegistry(byClass, byTag)
+    val builder = new Builder()
+    systemCodecs.foreach(builder.add)
+    bindings.foreach(builder.add)
+    builder.build
 
   val empty: EventCodecRegistry = apply()
+
+  private class Builder:
+    val byClass = mutable.Map.empty[Class[?], EventCodec]
+    val byTag   = mutable.Map.empty[Tag, EventCodec]
+
+    def add(cls: Class[?], codec: EventCodec): Unit =
+      require(!byClass.contains(cls), s"event ${cls.getName} already has a codec")
+      require(!byTag.contains(codec.tag), s"tag '${codec.tag}' is claimed by more than one codec")
+      byClass.put(cls, codec)
+      byTag.put(codec.tag, codec)
+
+    def build: EventCodecRegistry = new EventCodecRegistry(byClass.toMap, byTag.toMap)

--- a/parapet-core/src/main/scala/io/parapet/core/journal/EventCodecRegistry.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/journal/EventCodecRegistry.scala
@@ -1,13 +1,17 @@
 package io.parapet.core.journal
 
 import io.parapet.Event
+import io.parapet.core.Events
 import io.parapet.core.journal.EventCodec.Tag
 
 /** Resolves the [[EventCodec]].
   *
   * There is one codec per event type, bound to exactly one class and one tag.
   */
-final class EventCodecRegistry private (byClass: Map[Class[?], EventCodec], byTag: Map[Tag, EventCodec]):
+final class EventCodecRegistry private (
+    private val byClass: Map[Class[?], EventCodec],
+    private val byTag: Map[Tag, EventCodec]
+):
 
   /** The codec for `event`, or `None` when its type is not registered - i.e. the event cannot be encoded. */
   def codecFor(event: Event): Option[EventCodec] = byClass.get(event.getClass)
@@ -18,6 +22,15 @@ final class EventCodecRegistry private (byClass: Map[Class[?], EventCodec], byTa
   def codecForTag(tag: Tag): Option[EventCodec] = byTag.get(tag)
 
 object EventCodecRegistry:
+
+  private[core] def withSystemCodecs(registry: EventCodecRegistry): EventCodecRegistry =
+    val systemClass = classOf[Events.Registered]
+    require(!registry.byClass.contains(systemClass), s"event ${systemClass.getName} already has a codec")
+    require(!registry.byTag.contains(RegisteredEventCodec.tag), s"tag '${RegisteredEventCodec.tag}' is already claimed")
+    new EventCodecRegistry(
+      registry.byClass.updated(systemClass, RegisteredEventCodec),
+      registry.byTag.updated(RegisteredEventCodec.tag, RegisteredEventCodec)
+    )
 
   /** Builds a registry, rejecting a class or a tag that is claimed more than once. */
   def apply(bindings: (Class[?], EventCodec)*): EventCodecRegistry =

--- a/parapet-core/src/main/scala/io/parapet/core/journal/RegisteredEventCodec.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/journal/RegisteredEventCodec.scala
@@ -1,0 +1,23 @@
+package io.parapet.core.journal
+
+import io.parapet.core.Events.Registered
+import io.parapet.{Event, ProcessRef}
+
+import java.nio.charset.StandardCharsets.UTF_8
+import scala.util.Try
+
+private[core] object RegisteredEventCodec extends EventCodec:
+  val tag: String  = "parapet.registered"
+  val version: Int = 1
+
+  def encode(event: Event): Try[Array[Byte]] = Try {
+    event match
+      case Registered(child) => child.value.getBytes(UTF_8)
+      case other             => throw new IllegalArgumentException(s"cannot encode $other")
+  }
+
+  def decode(encodedVersion: Int, bytes: Array[Byte]): Try[Event] = Try {
+    if encodedVersion != version then
+      throw new IllegalArgumentException(s"unsupported Registered schema version: $encodedVersion")
+    Registered(ProcessRef[Event](new String(bytes, UTF_8)))
+  }

--- a/parapet-core/src/main/scala/io/parapet/core/processes/Noop.scala
+++ b/parapet-core/src/main/scala/io/parapet/core/processes/Noop.scala
@@ -1,13 +1,16 @@
 package io.parapet.core.processes
 
 import io.parapet.core.Process
+import io.parapet.{Event, ProcessRef}
 
 /** Built-in process that silently swallows every event sent to it.
   *
   * Registered automatically by the runtime under [[io.parapet.ProcessRef.NoopRef]] so user code can route messages to a
   * known sink (e.g., during shutdown) without producing dead-letter noise.
   */
-class Noop[F[_]] extends Process[F, io.parapet.Event, Nothing] {
+class Noop[F[_]] extends Process[F, Event, Nothing] {
+  override val ref: ProcessRef[Event] = ProcessRef.NoopRef
+
   override def handle: Receive = { case _ =>
     dsl.unit
   }

--- a/parapet-core/src/test/scala/io/parapet/ProcessRefSpec.scala
+++ b/parapet-core/src/test/scala/io/parapet/ProcessRefSpec.scala
@@ -1,0 +1,32 @@
+package io.parapet
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers.*
+
+class ProcessRefSpec extends AnyFunSuite:
+
+  test("child references are stable and scoped by their parent") {
+    val orders = ProcessRef.root[Event]("orders")
+    val billing = ProcessRef.root[Event]("billing")
+
+    orders.child[Event]("worker") shouldBe ProcessRef[Event]("orders/worker")
+    orders.child[Event]("worker") shouldBe orders.child[Event]("worker")
+    orders.child[Event]("worker") should not be billing.child[Event]("worker")
+    orders.child[Event]("worker").child[Event]("retry-1") shouldBe
+      ProcessRef[Event]("orders/worker/retry-1")
+  }
+
+  test("named reference segments must be canonical") {
+    Seq("", "worker/child", "-worker", "worker child", "воркер").foreach { invalid =>
+      assertThrows[IllegalArgumentException] {
+        ProcessRef.root[Event](invalid)
+      }
+    }
+
+    val root = ProcessRef.root[Event]("orders")
+    Seq("", "worker/child", "-worker", "worker child", "воркер").foreach { invalid =>
+      assertThrows[IllegalArgumentException] {
+        root.child[Event](invalid)
+      }
+    }
+  }

--- a/parapet-core/src/test/scala/io/parapet/ProcessRefSpec.scala
+++ b/parapet-core/src/test/scala/io/parapet/ProcessRefSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers.*
 class ProcessRefSpec extends AnyFunSuite:
 
   test("child references are stable and scoped by their parent") {
-    val orders = ProcessRef.root[Event]("orders")
+    val orders  = ProcessRef.root[Event]("orders")
     val billing = ProcessRef.root[Event]("billing")
 
     orders.child[Event]("worker") shouldBe ProcessRef[Event]("orders/worker")

--- a/parapet-core/src/test/scala/io/parapet/core/RecoveryContractSpec.scala
+++ b/parapet-core/src/test/scala/io/parapet/core/RecoveryContractSpec.scala
@@ -1,0 +1,147 @@
+package io.parapet.core
+
+import io.parapet.core.Dsl.WithDsl
+import io.parapet.core.Parapet.ParConfig
+import io.parapet.core.Scheduler.{Ok, SubmissionResult, Task}
+import io.parapet.core.exceptions.RecoveryContractViolation
+import io.parapet.core.journal.{EventCodecRegistry, JournalConfig, JournalStoreLocal}
+import io.parapet.effect.Monad.*
+import io.parapet.{Event, ProcessRef, Scope}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers.*
+
+import java.nio.file.Files
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
+import scala.jdk.CollectionConverters.*
+
+class RecoveryContractSpec extends AnyFunSuite with WithDsl[TestUtils.TestIO]:
+  import TestUtils.*
+  import TestUtils.given
+  import dsl.*
+
+  test("concurrent registration installs one process and records one marker") {
+    val fixture = newFixture()
+    val parent  = process(ProcessRef.root[Event]("parent"))
+    fixture.context.register(ProcessRef.SystemRef, parent).unsafeRun()
+
+    val childRef = parent.ref.child[Event]("worker")
+    val children = Vector(process(childRef), process(childRef))
+    val ready    = new CountDownLatch(children.size)
+    val start    = new CountDownLatch(1)
+    val results  = new ConcurrentLinkedQueue[Either[Throwable, ProcessRef.Unknown]]()
+
+    val threads = children.map { child =>
+      new Thread(() => {
+        ready.countDown()
+        start.await()
+        try results.add(Right(fixture.context.register(parent.ref, child).unsafeRun()))
+        catch case error: Throwable => results.add(Left(error))
+        ()
+      })
+    }
+
+    threads.foreach(_.start())
+    ready.await()
+    start.countDown()
+    threads.foreach(_.join())
+
+    val outcomes = results.iterator().asScala.toVector
+    outcomes.count(_.isRight) shouldBe 1
+    outcomes.collect { case Left(error) => error }.head shouldBe a[IllegalStateException]
+
+    fixture.context.stopJournal.unsafeRun()
+    val entries = fixture.store.read(0L).unsafeRun()
+
+    entries.count(_.receiver == parent.ref) shouldBe 1
+    children.exists(_ eq fixture.context.getProcessState(childRef).get.process) shouldBe true
+  }
+
+  test("recovery-enabled processes fail before executing Suspend unless they are a boundary") {
+    val fixture  = newFixture()
+    var executed = false
+
+    val regular = process(ProcessRef.root[Event]("regular"))
+    fixture.context.register(ProcessRef.SystemRef, regular).unsafeRun()
+
+    val interpreter = DslInterpreter[TestIO](fixture.context)
+    val regularFlow = suspend(TestIO.delay { executed = true })
+
+    assertThrows[RecoveryContractViolation] {
+      regularFlow
+        .foldMap(
+          interpreter.interpret(ProcessRef.SystemRef, fixture.context.getProcessState(regular.ref).get, Scope.empty)
+        )
+        .unsafeRun()
+    }
+    executed shouldBe false
+
+    assertThrows[RecoveryContractViolation] {
+      fork(eval { executed = true })
+        .foldMap(
+          interpreter.interpret(ProcessRef.SystemRef, fixture.context.getProcessState(regular.ref).get, Scope.empty)
+        )
+        .unsafeRun()
+    }
+    executed shouldBe false
+
+    assertThrows[RecoveryContractViolation] {
+      race(eval { executed = true }, eval { executed = true })
+        .foldMap(
+          interpreter.interpret(ProcessRef.SystemRef, fixture.context.getProcessState(regular.ref).get, Scope.empty)
+        )
+        .unsafeRun()
+    }
+    executed shouldBe false
+
+    val boundary = new Process[TestIO, Event, Event] with ReplayBoundary:
+      override val ref: ProcessRef[Event] = ProcessRef.root[Event]("storage")
+      def handle: Receive                 = PartialFunction.empty
+
+    fixture.context.register(ProcessRef.SystemRef, boundary).unsafeRun()
+    suspend(TestIO.delay { executed = true })
+      .foldMap(
+        interpreter.interpret(ProcessRef.SystemRef, fixture.context.getProcessState(boundary.ref).get, Scope.empty)
+      )
+      .unsafeRun()
+
+    executed shouldBe true
+    fixture.context.stopJournal.unsafeRun()
+  }
+
+  test("Suspend remains available when recovery is disabled") {
+    val fixture  = new RuntimeFixture
+    var executed = false
+
+    fixture.run(suspend(TestIO.delay { executed = true }))
+
+    executed shouldBe true
+  }
+
+  final private case class Fixture(
+      context: Context[TestIO],
+      store: JournalStoreLocal[TestIO]
+  )
+
+  private def newFixture(): Fixture =
+    val dir    = Files.createTempDirectory("recovery-contract")
+    val config = ParConfig.default.copy(
+      journal = JournalConfig(enabled = true, dataDir = dir.toString, batchSize = 1)
+    )
+    val store   = new JournalStoreLocal[TestIO](JournalStoreLocal.Config(dir))
+    val context = Context[TestIO](
+      config,
+      EventTransformers.empty,
+      journalStorage = Some(store),
+      codecRegistry = EventCodecRegistry.empty
+    ).unsafeRun()
+    val scheduler = new Scheduler[TestIO]:
+      def start: TestIO[Unit]                                  = TestIO.unit
+      def submit(task: Task[TestIO]): TestIO[SubmissionResult] = TestIO.pure(Ok)
+
+    context.bind(scheduler).unsafeRun()
+    Fixture(context, store)
+
+  private def process(processRef: ProcessRef[Event]): Process[TestIO, Event, Event] =
+    new Process[TestIO, Event, Event]:
+      override val ref: ProcessRef[Event] = processRef
+      def handle: Receive                 = PartialFunction.empty

--- a/parapet-core/src/test/scala/io/parapet/core/TestUtils.scala
+++ b/parapet-core/src/test/scala/io/parapet/core/TestUtils.scala
@@ -117,10 +117,7 @@ object TestUtils:
     val context: Context[TestIO] =
       Context[TestIO](ParConfig.default, EventTransformers.empty).unsafeRun()
 
-    context.bind(scheduler).unsafeRun()
-
-    private val noop: Noop[TestIO] = new Noop[TestIO]
-    context.register(ProcessRef.SystemRef, noop).unsafeRun()
+    context.bind(scheduler).unsafeRun() // creates the built-in Noop under ProcessRef.NoopRef
 
     captured.clear() // drop any boot-time envelopes captured by the stub scheduler
 
@@ -135,7 +132,7 @@ object TestUtils:
         .foldMap(
           impl.interpret(
             sender,
-            context.getProcessState(noop.ref).get,
+            context.getProcessState(ProcessRef.NoopRef).get,
             scope
           )
         )

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/ChildRecoveryIntgSpec.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/ChildRecoveryIntgSpec.scala
@@ -1,0 +1,101 @@
+package io.parapet.tests.intg.pario
+
+import io.parapet.core.Events.{Restored, Start}
+import io.parapet.core.Parapet.ParConfig
+import io.parapet.core.Process
+import io.parapet.core.snapshot.{Snapshot, SnapshotConfig, Snapshotable}
+import io.parapet.effect.ParIO
+import io.parapet.effect.ParIO.given
+import io.parapet.testutils.EventStore
+import io.parapet.tests.intg.BasicParIOSpec
+import io.parapet.{Event, ProcessRef}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers.*
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
+
+/** Recovery recursion: a restored parent re-spawns the children its state lists, and each child is restored from its
+  * own snapshot. Uses snapshots only (journal off), so the re-fold is a no-op and the test isolates the re-spawn.
+  */
+class ChildRecoveryIntgSpec extends AnyFunSuite with BasicParIOSpec:
+
+  import ChildRecoveryIntgSpec.*
+  import dsl.*
+
+  test("a restored parent re-spawns its children and they are restored from their own snapshots") {
+    val dir        = Files.createTempDirectory("child-recovery")
+    val managerRef = ProcessRef[Event]("crec-manager")
+    val workerRef  = ProcessRef[Event]("worker-w1")
+    val config     = ParConfig.default.copy(
+      snapshot = SnapshotConfig(enabled = true, dataDir = dir.toString, maxEventsPerSnapshot = 1)
+    )
+
+    // run 1: create worker-w1 and add 5 to it, so the manager (knows w1) and the worker (count=5) both snapshot to disk
+    val store1  = new EventStore[ParIO, Event]
+    val driver1 = onStart(CreateWorker("w1") ~> managerRef ++ (AddTo("w1", 5) ~> managerRef))
+    unsafeRun(store1.await(1, createApp(ct.pure(Seq(new Manager(managerRef, store1), driver1)), config0 = config).run))
+
+    // run 2: restart; recovery restores the manager, its Restored handler re-spawns worker-w1, and the recursion
+    // restores that child to its snapshot (count=5), which its own Restored handler reports.
+    val store2  = new EventStore[ParIO, Event]
+    val driver2 = onStart(unit)
+    unsafeRun(store2.await(1, createApp(ct.pure(Seq(new Manager(managerRef, store2), driver2)), config0 = config).run))
+
+    store2.get(workerRef) should contain(RestoredWith(5L))
+  }
+
+object ChildRecoveryIntgSpec:
+
+  final case class CreateWorker(id: String)  extends Event
+  final case class AddTo(id: String, n: Int) extends Event
+  final case class WAdd(n: Int)              extends Event
+  final case class Acked(count: Long)        extends Event
+  final case class RestoredWith(count: Long) extends Event
+
+  private def encodeCount(c: Long): Array[Byte] = ByteBuffer.allocate(8).putLong(c).array()
+  private def decodeCount(b: Array[Byte]): Long = ByteBuffer.wrap(b).getLong
+
+  /** A dynamic, snapshotable child: its state is a running count. */
+  final class Worker(override val ref: ProcessRef[Event], store: EventStore[ParIO, Event])
+      extends Process[ParIO, Event, Event]
+      with Snapshotable:
+
+    import dsl.*
+
+    @volatile var count: Long = 0
+
+    def serialize(): Array[Byte]          = encodeCount(count)
+    def restore(snapshot: Snapshot): Unit = count = decodeCount(snapshot.data)
+
+    def handle: Receive =
+      case Start    => unit
+      case Restored => eval(store.add(ref, RestoredWith(count)))
+      case WAdd(n)  => eval { count += n; store.add(ref, Acked(count)) }
+
+  /** A static, snapshotable parent: remembers its worker refs and re-spawns them on Restored. */
+  final class Manager(override val ref: ProcessRef[Event], store: EventStore[ParIO, Event])
+      extends Process[ParIO, Event, Event]
+      with Snapshotable:
+
+    import dsl.*
+
+    @volatile var workers: Map[String, ProcessRef[Event]] = Map.empty
+
+    def serialize(): Array[Byte]          = workers.keys.mkString(",").getBytes(UTF_8)
+    def restore(snapshot: Snapshot): Unit =
+      workers = new String(snapshot.data, UTF_8)
+        .split(",")
+        .filter(_.nonEmpty)
+        .map(id => id -> ProcessRef[Event](s"worker-$id"))
+        .toMap
+
+    def handle: Receive =
+      case Start    => unit
+      case Restored =>
+        workers.values.toList.foldLeft(unit)((acc, wref) => acc ++ register(ref, new Worker(wref, store)).map(_ => ()))
+      case CreateWorker(id) =>
+        val wref = ProcessRef[Event](s"worker-$id")
+        eval(workers += id -> wref) ++ register(ref, new Worker(wref, store)).map(_ => ())
+      case AddTo(id, n) => WAdd(n) ~> workers(id)

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/ChildRecoveryIntgSpec.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/ChildRecoveryIntgSpec.scala
@@ -41,9 +41,14 @@ class ChildRecoveryIntgSpec extends AnyFunSuite with BasicParIOSpec:
     // restores that child to its snapshot (count=5), which its own Restored handler reports.
     val store2  = new EventStore[ParIO, Event]
     val driver2 = onStart(unit)
-    unsafeRun(store2.await(1, createApp(ct.pure(Seq(new Manager(managerRef, store2), driver2)), config0 = config).run))
+    unsafeRun(
+      store2.await(
+        2,
+        createApp(ct.pure(Seq(new Manager(managerRef, store2, recordChildStart = true), driver2)), config0 = config).run
+      )
+    )
 
-    store2.get(workerRef) should contain(RestoredWith(5L))
+    store2.get(workerRef) shouldBe Seq(RestoredWith(5L), StartedWith(5L))
   }
 
 object ChildRecoveryIntgSpec:
@@ -53,13 +58,17 @@ object ChildRecoveryIntgSpec:
   final case class WAdd(n: Int)              extends Event
   final case class Acked(count: Long)        extends Event
   final case class RestoredWith(count: Long) extends Event
+  final case class StartedWith(count: Long)  extends Event
 
   private def encodeCount(c: Long): Array[Byte] = ByteBuffer.allocate(8).putLong(c).array()
   private def decodeCount(b: Array[Byte]): Long = ByteBuffer.wrap(b).getLong
 
   /** A dynamic, snapshotable child: its state is a running count. */
-  final class Worker(override val ref: ProcessRef[Event], store: EventStore[ParIO, Event])
-      extends Process[ParIO, Event, Event]
+  final class Worker(
+      override val ref: ProcessRef[Event],
+      store: EventStore[ParIO, Event],
+      recordStart: Boolean = false
+  ) extends Process[ParIO, Event, Event]
       with Snapshotable:
 
     import dsl.*
@@ -70,13 +79,16 @@ object ChildRecoveryIntgSpec:
     def restore(snapshot: Snapshot): Unit = count = decodeCount(snapshot.data)
 
     def handle: Receive =
-      case Start    => unit
+      case Start    => if recordStart then eval(store.add(ref, StartedWith(count))) else unit
       case Restored => eval(store.add(ref, RestoredWith(count)))
       case WAdd(n)  => eval { count += n; store.add(ref, Acked(count)) }
 
   /** A static, snapshotable parent: remembers its worker refs and re-spawns them on Restored. */
-  final class Manager(override val ref: ProcessRef[Event], store: EventStore[ParIO, Event])
-      extends Process[ParIO, Event, Event]
+  final class Manager(
+      override val ref: ProcessRef[Event],
+      store: EventStore[ParIO, Event],
+      recordChildStart: Boolean = false
+  ) extends Process[ParIO, Event, Event]
       with Snapshotable:
 
     import dsl.*
@@ -94,8 +106,10 @@ object ChildRecoveryIntgSpec:
     def handle: Receive =
       case Start    => unit
       case Restored =>
-        workers.values.toList.foldLeft(unit)((acc, wref) => acc ++ register(ref, new Worker(wref, store)).map(_ => ()))
+        workers.values.toList.foldLeft(unit)((acc, wref) =>
+          acc ++ register(ref, new Worker(wref, store, recordChildStart)).map(_ => ())
+        )
       case CreateWorker(id) =>
         val wref = ProcessRef[Event](s"worker-$id")
-        eval(workers += id -> wref) ++ register(ref, new Worker(wref, store)).map(_ => ())
+        eval(workers += id -> wref) ++ register(ref, new Worker(wref, store, recordChildStart)).map(_ => ())
       case AddTo(id, n) => WAdd(n) ~> workers(id)

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/RecoveryIntgSpec.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/RecoveryIntgSpec.scala
@@ -274,9 +274,9 @@ object RecoveryIntgSpec:
     def handle: Receive =
       case Initialize if recreateChild =>
         register(ref, new Counter(childRef, store, recordStart = true, recordInitialize = true))
-      case Initialize                  => unit
-      case Start                       => unit
-      case Store(n)                    =>
+      case Initialize => unit
+      case Start      => unit
+      case Store(n)   =>
         register(ref, new Counter(childRef, store)) ++
           suspend(ParIO.delay(ioCalls.incrementAndGet())).void ++
           (Add(n) ~> childRef)

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/RecoveryIntgSpec.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/RecoveryIntgSpec.scala
@@ -2,7 +2,7 @@ package io.parapet.tests.intg.pario
 
 import io.parapet.core.Events.{Initialize, Start}
 import io.parapet.core.Parapet.ParConfig
-import io.parapet.core.Process
+import io.parapet.core.{Process, ReplayBoundary}
 import io.parapet.core.journal.{EventCodec, EventCodecRegistry, JournalConfig, JournalStoreLocal}
 import io.parapet.effect.ParIO
 import io.parapet.effect.ParIO.given
@@ -14,6 +14,7 @@ import org.scalatest.matchers.should.Matchers.*
 
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Path}
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 
@@ -170,6 +171,54 @@ class RecoveryIntgSpec extends AnyFunSuite with BasicParIOSpec:
     store2.get(childRef) shouldBe Seq(InitializedWith(0L), StartedWith(0L))
   }
 
+  test("a replay boundary skips IO while its replayable child is recovered and replayed") {
+    val dir         = Files.createTempDirectory("recovery-boundary")
+    val boundaryRef = ProcessRef.root[Event]("storage")
+    val childRef    = boundaryRef.child[Event]("state")
+    val ioCalls     = new AtomicInteger(0)
+    val config      = ParConfig.default.copy(
+      journal = JournalConfig(enabled = true, dataDir = dir.toString, batchSize = 1)
+    )
+
+    val store1 = new EventStore[ParIO, Event]
+    unsafeRun(
+      store1.await(
+        1,
+        createApp(
+          ct.pure(
+            Seq(
+              new StorageBoundary(boundaryRef, childRef, store1, ioCalls, recreateChild = false),
+              onStart(Store(9) ~> boundaryRef)
+            )
+          ),
+          config0 = config,
+          eventCodecs0 = boundaryCodecs
+        ).run
+      )
+    )
+    ioCalls.get() shouldBe 1
+
+    val store2 = new EventStore[ParIO, Event]
+    unsafeRun(
+      store2.await(
+        3,
+        createApp(
+          ct.pure(
+            Seq(
+              new StorageBoundary(boundaryRef, childRef, store2, ioCalls, recreateChild = true),
+              onStart(unit)
+            )
+          ),
+          config0 = config,
+          eventCodecs0 = boundaryCodecs
+        ).run
+      )
+    )
+
+    ioCalls.get() shouldBe 1
+    store2.get(childRef) shouldBe Seq(InitializedWith(0L), Acked(9L), StartedWith(9L))
+  }
+
 object RecoveryIntgSpec:
 
   final case class Add(n: Int)                  extends Event
@@ -177,6 +226,7 @@ object RecoveryIntgSpec:
   final case class InitializedWith(count: Long) extends Event
   final case class StartedWith(count: Long)     extends Event
   case object Spawn                             extends Event
+  final case class Store(n: Int)                extends Event
 
   object AddCodec extends EventCodec:
     val tag: String                            = "add"
@@ -194,10 +244,42 @@ object RecoveryIntgSpec:
       case other => Failure(new IllegalArgumentException(s"cannot encode $other"))
     def decode(version: Int, bytes: Array[Byte]): Try[Event] = Success(Spawn)
 
+  object StoreCodec extends EventCodec:
+    val tag: String                            = "store"
+    val version: Int                           = 1
+    def encode(event: Event): Try[Array[Byte]] = event match
+      case Store(n) => Success(ByteBuffer.allocate(4).putInt(n).array())
+      case other    => Failure(new IllegalArgumentException(s"cannot encode $other"))
+    def decode(version: Int, bytes: Array[Byte]): Try[Event] = Success(Store(ByteBuffer.wrap(bytes).getInt))
+
   val codecs: EventCodecRegistry = EventCodecRegistry(classOf[Add] -> AddCodec)
 
   val dynamicCodecs: EventCodecRegistry =
     EventCodecRegistry(classOf[Add] -> AddCodec, classOf[Spawn.type] -> SpawnCodec)
+
+  val boundaryCodecs: EventCodecRegistry =
+    EventCodecRegistry(classOf[Add] -> AddCodec, classOf[Store] -> StoreCodec)
+
+  final class StorageBoundary(
+      override val ref: ProcessRef[Event],
+      childRef: ProcessRef[Event],
+      store: EventStore[ParIO, Event],
+      ioCalls: AtomicInteger,
+      recreateChild: Boolean
+  ) extends Process[ParIO, Event, Event]
+      with ReplayBoundary:
+
+    import dsl.*
+
+    def handle: Receive =
+      case Initialize if recreateChild =>
+        register(ref, new Counter(childRef, store, recordStart = true, recordInitialize = true))
+      case Initialize                  => unit
+      case Start                       => unit
+      case Store(n)                    =>
+        register(ref, new Counter(childRef, store)) ++
+          suspend(ParIO.delay(ioCalls.incrementAndGet())).void ++
+          (Add(n) ~> childRef)
 
   final class Parent(
       override val ref: ProcessRef[Event],

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/RecoveryIntgSpec.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/RecoveryIntgSpec.scala
@@ -1,9 +1,9 @@
 package io.parapet.tests.intg.pario
 
-import io.parapet.core.Events.Start
+import io.parapet.core.Events.{Initialize, Start}
 import io.parapet.core.Parapet.ParConfig
 import io.parapet.core.Process
-import io.parapet.core.journal.{EventCodec, EventCodecRegistry, JournalConfig}
+import io.parapet.core.journal.{EventCodec, EventCodecRegistry, JournalConfig, JournalStoreLocal}
 import io.parapet.effect.ParIO
 import io.parapet.effect.ParIO.given
 import io.parapet.testutils.EventStore
@@ -13,7 +13,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers.*
 
 import java.nio.ByteBuffer
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
+import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 
 class RecoveryIntgSpec extends AnyFunSuite with BasicParIOSpec:
@@ -36,16 +37,146 @@ class RecoveryIntgSpec extends AnyFunSuite with BasicParIOSpec:
     // Run 2 (same data dir, fresh instance, no snapshot): boot re-folds the journal onto the counter before it goes
     // live, so its state is reconstructed from the record alone - the driver sends nothing.
     val store2   = new EventStore[ParIO, Event]
-    val counter2 = new Counter(ref, store2)
+    val counter2 = new Counter(ref, store2, recordInitialize = true, recordStart = true)
     val driver2  = onStart(unit)
-    unsafeRun(store2.await(3, createApp(ct.pure(Seq(counter2, driver2)), config0 = config, eventCodecs0 = codecs).run))
+    unsafeRun(store2.await(5, createApp(ct.pure(Seq(counter2, driver2)), config0 = config, eventCodecs0 = codecs).run))
     counter2.count shouldBe 6L
+    store2.get(ref) shouldBe Seq(InitializedWith(0L), Acked(1L), Acked(3L), Acked(6L), StartedWith(6L))
+  }
+
+  test("a registration marker recovers a child created by a replayed parent event") {
+    val dir       = Files.createTempDirectory("recovery-child-intg")
+    val parentRef = ProcessRef[Event]("rec-parent")
+    val childRef  = ProcessRef[Event]("rec-child")
+    val config    = ParConfig.default.copy(
+      journal = JournalConfig(enabled = true, dataDir = dir.toString, batchSize = 1)
+    )
+
+    val store1  = new EventStore[ParIO, Event]
+    val parent1 = new Parent(parentRef, childRef, store1)
+    val driver1 = onStart(Spawn ~> parentRef)
+    unsafeRun(
+      store1.await(
+        1,
+        createApp(ct.pure(Seq(parent1, driver1)), config0 = config, eventCodecs0 = dynamicCodecs).run
+      )
+    )
+
+    val entries = new JournalStoreLocal[ParIO](JournalStoreLocal.Config(dir)).read(0L).unsafeRunSync()
+    entries.map(_.receiver) shouldBe Vector(parentRef, parentRef, childRef)
+    entries.map(_.tag) shouldBe Vector(SpawnCodec.tag, "parapet.registered", AddCodec.tag)
+
+    val store2  = new EventStore[ParIO, Event]
+    val parent2 = new Parent(parentRef, childRef, store2, recordChildStart = true)
+    val driver2 = onStart(unit)
+    unsafeRun(
+      store2.await(
+        2,
+        createApp(ct.pure(Seq(parent2, driver2)), config0 = config, eventCodecs0 = dynamicCodecs).run
+      )
+    )
+
+    store2.get(childRef) shouldBe Seq(Acked(7L), StartedWith(7L))
+  }
+
+  test("recovery rejects a child delivery that appears before its registration marker") {
+    val dir       = Files.createTempDirectory("recovery-missing-marker")
+    val parentRef = ProcessRef[Event]("missing-marker-parent")
+    val childRef  = ProcessRef[Event]("missing-marker-child")
+    val config    = ParConfig.default.copy(
+      journal = JournalConfig(enabled = true, dataDir = dir.toString, batchSize = 1)
+    )
+
+    val store1 = new EventStore[ParIO, Event]
+    unsafeRun(
+      store1.await(
+        1,
+        createApp(
+          ct.pure(Seq(new Parent(parentRef, childRef, store1), onStart(Spawn ~> parentRef))),
+          config0 = config,
+          eventCodecs0 = dynamicCodecs
+        ).run
+      )
+    )
+
+    val entries = new JournalStoreLocal[ParIO](JournalStoreLocal.Config(dir)).read(0L).unsafeRunSync()
+    val marker  = entries.find(_.tag == "parapet.registered").getOrElse(fail("registration marker not recorded"))
+    deleteSingleEntrySegment(dir, marker.seq)
+
+    val error = intercept[IllegalStateException] {
+      unsafeRun(
+        createApp(
+          ct.pure(Seq(new Parent(parentRef, childRef, new EventStore[ParIO, Event]), onStart(unit))),
+          config0 = config,
+          eventCodecs0 = dynamicCodecs
+        ).run
+      )
+    }
+
+    error.getMessage should include(s"process $childRef received entry")
+    error.getMessage should include("before recovery")
+  }
+
+  test("recovery prepares a child whose registration marker was lost from the journal tail") {
+    val dir       = Files.createTempDirectory("recovery-lost-marker-tail")
+    val parentRef = ProcessRef[Event]("tail-parent")
+    val childRef  = ProcessRef[Event]("tail-child")
+    val config    = ParConfig.default.copy(
+      journal = JournalConfig(enabled = true, dataDir = dir.toString, batchSize = 1)
+    )
+
+    val store1 = new EventStore[ParIO, Event]
+    unsafeRun(
+      store1.await(
+        1,
+        createApp(
+          ct.pure(Seq(new Parent(parentRef, childRef, store1), onStart(Spawn ~> parentRef))),
+          config0 = config,
+          eventCodecs0 = dynamicCodecs
+        ).run
+      )
+    )
+
+    val entries    = new JournalStoreLocal[ParIO](JournalStoreLocal.Config(dir)).read(0L).unsafeRunSync()
+    val marker     = entries.find(_.tag == "parapet.registered").getOrElse(fail("registration marker not recorded"))
+    val childEntry = entries.find(_.receiver == childRef).getOrElse(fail("child delivery not recorded"))
+    deleteSingleEntrySegment(dir, marker.seq)
+    deleteSingleEntrySegment(dir, childEntry.seq)
+
+    val store2 = new EventStore[ParIO, Event]
+    unsafeRun(
+      store2.await(
+        2,
+        createApp(
+          ct.pure(
+            Seq(
+              new Parent(
+                parentRef,
+                childRef,
+                store2,
+                recordChildStart = true,
+                recordChildInitialize = true
+              ),
+              onStart(unit)
+            )
+          ),
+          config0 = config,
+          eventCodecs0 = dynamicCodecs
+        ).run,
+        timeout = 5.seconds
+      )
+    )
+
+    store2.get(childRef) shouldBe Seq(InitializedWith(0L), StartedWith(0L))
   }
 
 object RecoveryIntgSpec:
 
-  final case class Add(n: Int)        extends Event
-  final case class Acked(count: Long) extends Event
+  final case class Add(n: Int)                  extends Event
+  final case class Acked(count: Long)           extends Event
+  final case class InitializedWith(count: Long) extends Event
+  final case class StartedWith(count: Long)     extends Event
+  case object Spawn                             extends Event
 
   object AddCodec extends EventCodec:
     val tag: String                            = "add"
@@ -55,16 +186,61 @@ object RecoveryIntgSpec:
       case other  => Failure(new IllegalArgumentException(s"cannot encode $other"))
     def decode(version: Int, bytes: Array[Byte]): Try[Event] = Success(Add(ByteBuffer.wrap(bytes).getInt))
 
+  object SpawnCodec extends EventCodec:
+    val tag: String                            = "spawn"
+    val version: Int                           = 1
+    def encode(event: Event): Try[Array[Byte]] = event match
+      case Spawn => Success(Array.emptyByteArray)
+      case other => Failure(new IllegalArgumentException(s"cannot encode $other"))
+    def decode(version: Int, bytes: Array[Byte]): Try[Event] = Success(Spawn)
+
   val codecs: EventCodecRegistry = EventCodecRegistry(classOf[Add] -> AddCodec)
 
-  /** A journaled counter: each `Add` folds into `count` and acks, so the recorded deliveries alone reconstruct it. */
-  final class Counter(override val ref: ProcessRef[Event], store: EventStore[ParIO, Event])
-      extends Process[ParIO, Event, Event]:
+  val dynamicCodecs: EventCodecRegistry =
+    EventCodecRegistry(classOf[Add] -> AddCodec, classOf[Spawn.type] -> SpawnCodec)
+
+  final class Parent(
+      override val ref: ProcessRef[Event],
+      childRef: ProcessRef[Event],
+      store: EventStore[ParIO, Event],
+      recordChildStart: Boolean = false,
+      recordChildInitialize: Boolean = false
+  ) extends Process[ParIO, Event, Event]:
 
     import dsl.*
 
-    @volatile var count: Long = 0
+    def handle: Receive =
+      case Start => unit
+      case Spawn =>
+        register(ref, new Counter(childRef, store, recordChildStart, recordChildInitialize)) ++ (Add(7) ~> childRef)
+
+  /** A journaled counter: each `Add` folds into `count` and acks, so the recorded deliveries alone reconstruct it. */
+  final class Counter(
+      override val ref: ProcessRef[Event],
+      store: EventStore[ParIO, Event],
+      recordStart: Boolean = false,
+      recordInitialize: Boolean = false
+  ) extends Process[ParIO, Event, Event]:
+
+    import dsl.*
+
+    @volatile var count: Long          = 0
+    @volatile var initialized: Boolean = false
 
     def handle: Receive =
-      case Start  => unit
-      case Add(n) => eval { count += n; store.add(ref, Acked(count)) }
+      case Initialize =>
+        eval {
+          initialized = true
+          if recordInitialize then store.add(ref, InitializedWith(count))
+        }
+      case Start  => if recordStart then eval(store.add(ref, StartedWith(count))) else unit
+      case Add(n) =>
+        eval {
+          require(initialized, "Add was delivered before Initialize")
+          count += n
+          store.add(ref, Acked(count))
+        }
+
+  private def deleteSingleEntrySegment(dir: Path, seq: Long): Unit =
+    val value = f"$seq%020d"
+    Files.delete(dir.resolve(s"$value-$value.jrnl"))

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/RecoveryIntgSpec.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/RecoveryIntgSpec.scala
@@ -1,9 +1,10 @@
 package io.parapet.tests.intg.pario
 
-import io.parapet.core.Events.{Initialize, Start}
+import io.parapet.core.Events.{Initialize, Restored, Start}
 import io.parapet.core.Parapet.ParConfig
 import io.parapet.core.{Process, ReplayBoundary}
 import io.parapet.core.journal.{EventCodec, EventCodecRegistry, JournalConfig, JournalStoreLocal}
+import io.parapet.core.snapshot.{Snapshot, SnapshotConfig, SnapshotStorageLocal, Snapshotable}
 import io.parapet.effect.ParIO
 import io.parapet.effect.ParIO.given
 import io.parapet.testutils.EventStore
@@ -219,6 +220,140 @@ class RecoveryIntgSpec extends AnyFunSuite with BasicParIOSpec:
     store2.get(childRef) shouldBe Seq(InitializedWith(0L), Acked(9L), StartedWith(9L))
   }
 
+  test("a snapshot restores state and the journal tail is not re-folded on top of it") {
+    val dir        = Files.createTempDirectory("recovery-snap-journal")
+    val journalDir = dir.resolve("journal").toString
+    val snapDir    = dir.resolve("snapshots").toString
+    val ref        = ProcessRef[Event]("snap-journal-counter")
+    val config     = ParConfig.default.copy(
+      journal = JournalConfig(enabled = true, dataDir = journalDir, batchSize = 1),
+      snapshot = SnapshotConfig(enabled = true, dataDir = snapDir, maxEventsPerSnapshot = 1)
+    )
+
+    // Run 1: three Adds are both journaled and (every delivery) snapshotted.
+    val store1   = new EventStore[ParIO, Event]
+    val counter1 = new SnapCounter(ref, store1)
+    val driver1  = onStart((1 to 3).map(i => Add(i) ~> ref).reduce(_ ++ _))
+    unsafeRun(store1.await(3, createApp(ct.pure(Seq(counter1, driver1)), config0 = config, eventCodecs0 = codecs).run))
+    counter1.count shouldBe 6L
+
+    // A snapshot covering at least the first delivery must exist, so recovery restores a non-empty prefix.
+    val snapSeq = new SnapshotStorageLocal[ParIO](SnapshotStorageLocal.Config(Path.of(snapDir)))
+      .latest(ref)
+      .unsafeRunSync()
+      .map(_.metadata.seq)
+      .getOrElse(0L)
+    snapSeq should be > 0L
+
+    // Run 2: state comes back from the snapshot; entries at or below the snapshot boundary must NOT be re-folded.
+    // `recordAcked = false` silences replay-time acks so the awaited event count is deterministic regardless of
+    // exactly where the snapshot boundary landed.
+    val store2   = new EventStore[ParIO, Event]
+    val counter2 = new SnapCounter(ref, store2, recordAcked = false, recordStart = true)
+    unsafeRun(
+      store2.await(1, createApp(ct.pure(Seq(counter2, onStart(unit))), config0 = config, eventCodecs0 = codecs).run)
+    )
+
+    counter2.count shouldBe 6L                    // restored once - NOT re-folded to more than 6
+    store2.get(ref) shouldBe Seq(StartedWith(6L)) // went live with the full, correct state
+  }
+
+  test("replay does not append new entries to the journal") {
+    val dir    = Files.createTempDirectory("recovery-no-append")
+    val ref    = ProcessRef[Event]("no-append-counter")
+    val config = ParConfig.default.copy(journal = JournalConfig(enabled = true, dataDir = dir.toString, batchSize = 1))
+
+    val store1  = new EventStore[ParIO, Event]
+    val driver1 = onStart((1 to 3).map(i => Add(i) ~> ref).reduce(_ ++ _))
+    unsafeRun(
+      store1.await(
+        3,
+        createApp(ct.pure(Seq(new Counter(ref, store1), driver1)), config0 = config, eventCodecs0 = codecs).run
+      )
+    )
+    val before = new JournalStoreLocal[ParIO](JournalStoreLocal.Config(dir)).read(0L).unsafeRunSync().map(_.seq)
+
+    // Run 2 recovers (replay re-folds the three Adds) then goes live; the driver sends nothing.
+    val store2   = new EventStore[ParIO, Event]
+    val counter2 = new Counter(ref, store2, recordStart = true)
+    unsafeRun(
+      store2.await(4, createApp(ct.pure(Seq(counter2, onStart(unit))), config0 = config, eventCodecs0 = codecs).run)
+    )
+    val after = new JournalStoreLocal[ParIO](JournalStoreLocal.Config(dir)).read(0L).unsafeRunSync().map(_.seq)
+
+    counter2.count shouldBe 6L
+    after shouldBe before // replay recorded nothing new
+  }
+
+  test("a replayed sender does not re-emit its downstream sends") {
+    val dir      = Files.createTempDirectory("recovery-suppress")
+    val relayRef = ProcessRef[Event]("relay")
+    val childRef = ProcessRef[Event]("relay-child")
+    val config = ParConfig.default.copy(journal = JournalConfig(enabled = true, dataDir = dir.toString, batchSize = 1))
+
+    // Run 1: driver -> relay: Emit(5); relay -> child: Add(5). Both deliveries are journaled.
+    val store1  = new EventStore[ParIO, Event]
+    val relay1  = new Relay(relayRef, childRef)
+    val child1  = new Counter(childRef, store1)
+    val driver1 = onStart(Emit(5) ~> relayRef)
+    unsafeRun(
+      store1.await(
+        1,
+        createApp(ct.pure(Seq(relay1, child1, driver1)), config0 = config, eventCodecs0 = relayCodecs).run
+      )
+    )
+
+    // Run 2: replay drives Emit -> relay (which re-sends Add -> child, and that send must be suppressed) and the
+    // recorded Add -> child. If the send were not suppressed the child would fold Add(5) twice.
+    val store2 = new EventStore[ParIO, Event]
+    val child2 = new Counter(childRef, store2, recordStart = true)
+    unsafeRun(
+      store2.await(
+        2,
+        createApp(
+          ct.pure(Seq(new Relay(relayRef, childRef), child2, onStart(unit))),
+          config0 = config,
+          eventCodecs0 = relayCodecs
+        ).run
+      )
+    )
+
+    child2.count shouldBe 5L // folded once, not 10
+    store2.get(childRef) shouldBe Seq(Acked(5L), StartedWith(5L))
+  }
+
+  test("recovery decodes journal entries written by an earlier codec version") {
+    val dir    = Files.createTempDirectory("recovery-versioned")
+    val ref    = ProcessRef[Event]("versioned-counter")
+    val config = ParConfig.default.copy(journal = JournalConfig(enabled = true, dataDir = dir.toString, batchSize = 1))
+
+    // Run 1: recorded with the v1 codec.
+    val store1  = new EventStore[ParIO, Event]
+    val driver1 = onStart((1 to 3).map(i => Add(i) ~> ref).reduce(_ ++ _))
+    unsafeRun(
+      store1.await(
+        3,
+        createApp(ct.pure(Seq(new Counter(ref, store1), driver1)), config0 = config, eventCodecs0 = codecs).run
+      )
+    )
+    val versions = new JournalStoreLocal[ParIO](JournalStoreLocal.Config(dir))
+      .read(0L)
+      .unsafeRunSync()
+      .filter(_.tag == AddCodec.tag)
+      .map(_.schemaVersion)
+      .distinct
+    versions shouldBe Vector(1)
+
+    // Run 2: the registry now holds a v2 codec for the same tag; its decode must read the v1 bytes.
+    val store2   = new EventStore[ParIO, Event]
+    val counter2 = new Counter(ref, store2, recordStart = true)
+    unsafeRun(
+      store2.await(4, createApp(ct.pure(Seq(counter2, onStart(unit))), config0 = config, eventCodecs0 = codecsV2).run)
+    )
+
+    counter2.count shouldBe 6L
+  }
+
 object RecoveryIntgSpec:
 
   final case class Add(n: Int)                  extends Event
@@ -227,6 +362,8 @@ object RecoveryIntgSpec:
   final case class StartedWith(count: Long)     extends Event
   case object Spawn                             extends Event
   final case class Store(n: Int)                extends Event
+  final case class RestoredWith(count: Long)    extends Event
+  final case class Emit(n: Int)                 extends Event
 
   object AddCodec extends EventCodec:
     val tag: String                            = "add"
@@ -252,13 +389,40 @@ object RecoveryIntgSpec:
       case other    => Failure(new IllegalArgumentException(s"cannot encode $other"))
     def decode(version: Int, bytes: Array[Byte]): Try[Event] = Success(Store(ByteBuffer.wrap(bytes).getInt))
 
+  /** Same tag as [[AddCodec]] but schema version 2 (8-byte payload). Decodes both versions, so it can read entries
+    * recorded by the v1 codec.
+    */
+  object AddCodecV2 extends EventCodec:
+    val tag: String                            = "add"
+    val version: Int                           = 2
+    def encode(event: Event): Try[Array[Byte]] = event match
+      case Add(n) => Success(ByteBuffer.allocate(8).putLong(n.toLong).array())
+      case other  => Failure(new IllegalArgumentException(s"cannot encode $other"))
+    def decode(version: Int, bytes: Array[Byte]): Try[Event] = version match
+      case 1     => Success(Add(ByteBuffer.wrap(bytes).getInt))
+      case 2     => Success(Add(ByteBuffer.wrap(bytes).getLong.toInt))
+      case other => Failure(new IllegalArgumentException(s"unsupported add version $other"))
+
+  object EmitCodec extends EventCodec:
+    val tag: String                            = "emit"
+    val version: Int                           = 1
+    def encode(event: Event): Try[Array[Byte]] = event match
+      case Emit(n) => Success(ByteBuffer.allocate(4).putInt(n).array())
+      case other   => Failure(new IllegalArgumentException(s"cannot encode $other"))
+    def decode(version: Int, bytes: Array[Byte]): Try[Event] = Success(Emit(ByteBuffer.wrap(bytes).getInt))
+
   val codecs: EventCodecRegistry = EventCodecRegistry(classOf[Add] -> AddCodec)
+
+  val codecsV2: EventCodecRegistry = EventCodecRegistry(classOf[Add] -> AddCodecV2)
 
   val dynamicCodecs: EventCodecRegistry =
     EventCodecRegistry(classOf[Add] -> AddCodec, classOf[Spawn.type] -> SpawnCodec)
 
   val boundaryCodecs: EventCodecRegistry =
     EventCodecRegistry(classOf[Add] -> AddCodec, classOf[Store] -> StoreCodec)
+
+  val relayCodecs: EventCodecRegistry =
+    EventCodecRegistry(classOf[Add] -> AddCodec, classOf[Emit] -> EmitCodec)
 
   final class StorageBoundary(
       override val ref: ProcessRef[Event],
@@ -322,6 +486,42 @@ object RecoveryIntgSpec:
           count += n
           store.add(ref, Acked(count))
         }
+
+  /** A snapshotable counter: its state is a running count, so it can be restored from a snapshot instead of re-folded.
+    */
+  final class SnapCounter(
+      override val ref: ProcessRef[Event],
+      store: EventStore[ParIO, Event],
+      recordAcked: Boolean = true,
+      recordStart: Boolean = false,
+      recordRestored: Boolean = false
+  ) extends Process[ParIO, Event, Event]
+      with Snapshotable:
+
+    import dsl.*
+
+    @volatile var count: Long = 0
+
+    def serialize(): Array[Byte]          = ByteBuffer.allocate(8).putLong(count).array()
+    def restore(snapshot: Snapshot): Unit = count = ByteBuffer.wrap(snapshot.data).getLong
+
+    def handle: Receive =
+      case Initialize => unit
+      case Restored   => if recordRestored then eval(store.add(ref, RestoredWith(count))) else unit
+      case Start      => if recordStart then eval(store.add(ref, StartedWith(count))) else unit
+      case Add(n)     => eval { count += n; if recordAcked then store.add(ref, Acked(count)) }
+
+  /** Relays each `Emit(n)` as an `Add(n)` to a fixed child - a sender whose send is exercised during replay. */
+  final class Relay(
+      override val ref: ProcessRef[Event],
+      childRef: ProcessRef[Event]
+  ) extends Process[ParIO, Event, Event]:
+
+    import dsl.*
+
+    def handle: Receive =
+      case Start   => unit
+      case Emit(n) => Add(n) ~> childRef
 
   private def deleteSingleEntrySegment(dir: Path, seq: Long): Unit =
     val value = f"$seq%020d"

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/RecoveryIntgSpec.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/RecoveryIntgSpec.scala
@@ -1,0 +1,70 @@
+package io.parapet.tests.intg.pario
+
+import io.parapet.core.Events.Start
+import io.parapet.core.Parapet.ParConfig
+import io.parapet.core.Process
+import io.parapet.core.journal.{EventCodec, EventCodecRegistry, JournalConfig}
+import io.parapet.effect.ParIO
+import io.parapet.effect.ParIO.given
+import io.parapet.testutils.EventStore
+import io.parapet.tests.intg.BasicParIOSpec
+import io.parapet.{Event, ProcessRef}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers.*
+
+import java.nio.ByteBuffer
+import java.nio.file.Files
+import scala.util.{Failure, Success, Try}
+
+class RecoveryIntgSpec extends AnyFunSuite with BasicParIOSpec:
+
+  import RecoveryIntgSpec.*
+  import dsl.*
+
+  test("a restart re-folds the recorded journal to reconstruct process state (no snapshot)") {
+    val dir    = Files.createTempDirectory("recovery-intg")
+    val ref    = ProcessRef[Event]("rec-counter")
+    val config = ParConfig.default.copy(journal = JournalConfig(enabled = true, dataDir = dir.toString, batchSize = 1))
+
+    // Run 1: three Add deliveries are recorded to the journal.
+    val store1   = new EventStore[ParIO, Event]
+    val counter1 = new Counter(ref, store1)
+    val driver1  = onStart((1 to 3).map(i => Add(i) ~> ref).reduce(_ ++ _))
+    unsafeRun(store1.await(3, createApp(ct.pure(Seq(counter1, driver1)), config0 = config, eventCodecs0 = codecs).run))
+    counter1.count shouldBe 6L
+
+    // Run 2 (same data dir, fresh instance, no snapshot): boot re-folds the journal onto the counter before it goes
+    // live, so its state is reconstructed from the record alone - the driver sends nothing.
+    val store2   = new EventStore[ParIO, Event]
+    val counter2 = new Counter(ref, store2)
+    val driver2  = onStart(unit)
+    unsafeRun(store2.await(3, createApp(ct.pure(Seq(counter2, driver2)), config0 = config, eventCodecs0 = codecs).run))
+    counter2.count shouldBe 6L
+  }
+
+object RecoveryIntgSpec:
+
+  final case class Add(n: Int)        extends Event
+  final case class Acked(count: Long) extends Event
+
+  object AddCodec extends EventCodec:
+    val tag: String                            = "add"
+    val version: Int                           = 1
+    def encode(event: Event): Try[Array[Byte]] = event match
+      case Add(n) => Success(ByteBuffer.allocate(4).putInt(n).array())
+      case other  => Failure(new IllegalArgumentException(s"cannot encode $other"))
+    def decode(version: Int, bytes: Array[Byte]): Try[Event] = Success(Add(ByteBuffer.wrap(bytes).getInt))
+
+  val codecs: EventCodecRegistry = EventCodecRegistry(classOf[Add] -> AddCodec)
+
+  /** A journaled counter: each `Add` folds into `count` and acks, so the recorded deliveries alone reconstruct it. */
+  final class Counter(override val ref: ProcessRef[Event], store: EventStore[ParIO, Event])
+      extends Process[ParIO, Event, Event]:
+
+    import dsl.*
+
+    @volatile var count: Long = 0
+
+    def handle: Receive =
+      case Start  => unit
+      case Add(n) => eval { count += n; store.add(ref, Acked(count)) }

--- a/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/SnapshotIntegrationSpec.scala
+++ b/parapet-pario/src/test/scala/io/parapet/tests/intg/pario/SnapshotIntegrationSpec.scala
@@ -50,7 +50,7 @@ class SnapshotIntegrationSpec extends AnyFunSuite with BasicParIOSpec:
     latest.metadata.processRef shouldBe counterRef
   }
 
-  test("a restarted app restores the process from its snapshot, delivers Restored, and continues the seq") {
+  test("a restarted app restores the process, delivers Restored then Start, and continues the seq") {
     val dir        = Files.createTempDirectory("snapshot-restart")
     val counterRef = ProcessRef[Event]("snap-restart-counter")
     val config     = ParConfig.default.copy(
@@ -66,13 +66,12 @@ class SnapshotIntegrationSpec extends AnyFunSuite with BasicParIOSpec:
 
     // --- run 2: restart over the same data dir ---
     val store2   = new EventStore[ParIO, Event]
-    val counter2 = new Counter(counterRef, store2) // fresh instance, count starts at 0
+    val counter2 = new Counter(counterRef, store2, recordStart = true) // fresh instance, count starts at 0
     val driver2  = onStart(Probe ~> counterRef)
-    unsafeRun(store2.await(2, createApp(ct.pure(Seq(counter2, driver2)), config0 = config).run))
+    unsafeRun(store2.await(3, createApp(ct.pure(Seq(counter2, driver2)), config0 = config).run))
 
-    counter2.count shouldBe 15L                                        // state came back from disk
-    store2.get(counterRef).headOption shouldBe Some(RestoredWith(15L)) // Restored delivered, not Start
-    store2.get(counterRef) should contain(Acked(15L))                  // then handled the live Probe
+    counter2.count shouldBe 15L // state came back from disk
+    store2.get(counterRef) shouldBe Seq(RestoredWith(15L), StartedWith(15L), Acked(15L))
 
     val run2Seq = storage.latest(counterRef).unsafeRunSync().getOrElse(fail("no snapshot")).metadata.seq
     run2Seq should be > run1Seq // seq continued past the previous run
@@ -84,13 +83,17 @@ object SnapshotIntegrationSpec:
   case object Probe                          extends Event
   final case class Acked(count: Long)        extends Event
   final case class RestoredWith(count: Long) extends Event
+  final case class StartedWith(count: Long)  extends Event
 
   private def encodeCount(count: Long): Array[Byte] = ByteBuffer.allocate(8).putLong(count).array()
   private def decodeCount(bytes: Array[Byte]): Long = ByteBuffer.wrap(bytes).getLong
 
   /** A counting process that opts into snapshotting; its serialized state is just the running count. */
-  final class Counter(override val ref: ProcessRef[Event], store: EventStore[ParIO, Event])
-      extends Process[ParIO, Event, Event]
+  final class Counter(
+      override val ref: ProcessRef[Event],
+      store: EventStore[ParIO, Event],
+      recordStart: Boolean = false
+  ) extends Process[ParIO, Event, Event]
       with Snapshotable:
 
     import dsl.*
@@ -101,7 +104,7 @@ object SnapshotIntegrationSpec:
     def restore(snapshot: Snapshot): Unit = count = decodeCount(snapshot.data)
 
     def handle: Receive =
-      case Start    => unit
+      case Start    => if recordStart then eval(store.add(ref, StartedWith(count))) else unit
       case Restored => eval(store.add(ref, RestoredWith(count)))
       case Add(n)   => eval { count += n; store.add(ref, Acked(count)) }
       case Probe    => eval(store.add(ref, Acked(count)))

--- a/parapet-testkit/src/main/scala/io/parapet/tests/intg/ProcessLifecycleSpec.scala
+++ b/parapet-testkit/src/main/scala/io/parapet/tests/intg/ProcessLifecycleSpec.scala
@@ -170,10 +170,10 @@ abstract class ProcessLifecycleSpec[F[_]] extends AnyFlatSpec with IntegrationSp
     val init   = onStart(Seq(DataEvent(1), DataEvent(2), Stop) ~> process.ref)
     val config = ParConfig.default.withDevMode.withWorkerCount(1)
 
-    unsafeRun(eventStore.await(3, createApp(ct.pure(Seq(init, process)), config0 = config).run))
+    unsafeRun(eventStore.await(5, createApp(ct.pure(Seq(init, process)), config0 = config).run))
 
-    eventStore.size shouldBe 4
-    eventStore.get(process.ref) shouldBe Seq(Start, DataEvent(1), DataEvent(2), Stop)
+    eventStore.size shouldBe 5
+    eventStore.get(process.ref) shouldBe Seq(Initialize, Start, DataEvent(1), DataEvent(2), Stop)
 
   }
 


### PR DESCRIPTION
Recovery: restore from snapshots, replay from the journal

Reconstructs process state after a restart by restoring each process's latest snapshot and re-folding the journal entries recorded after it, then going live — building on the snapshot (#73) and journal (#74) machinery.

Boot & recovery orchestration — New Recovery and BootMode. Context.boot now drives startup: enter Replaying, seed the delivery/envelope-id counters past the journal, restore snapshots, deliver Initialize/Restored, re-fold the journal tail, switch to Live, then deliver Start. ParApp wires it in.

Lifecycle events (Events) — Initialize (fresh process, delivered before Start on every boot regardless of persistence), Restored (after a snapshot restore), and Start (go-live). Existing processes are unaffected — these are opt-in via handle.

Replay gate (DslInterpreter) — While replaying, outward effects are suppressed (Send/Forward), Delay is zeroed, and Offload is a no-op, since recorded deliveries are re-injected. In a recoverable process, suspend/fork/race now fail loud with RecoveryContractViolation the first time they run (not at recovery time), because they can't be reconstructed from the record.

ReplayBoundary — A marker trait for processes that own IO, concurrency, or timers. Their recorded inputs are not re-executed on replay (the events they emitted already reconstruct downstream consumers), and inside them suspend/fork/race are permitted. This is the sanctioned home for the operations the replay gate forbids elsewhere.

Hierarchical refs (ProcessRef) — ProcessRef.root(name) and parent.child(name) produce stable, deterministic parent/name addresses (validated segments), so recovery can recreate a child under the identity its history expects. Context.register is reordered to reserve → record → publish with rollback on a failed marker write.

Dynamic-child recovery — When a parent registers a child, a Registered(child) marker is journaled (RegisteredEventCodec, tag parapet.registered) and replayed to synchronize recreation of children a replayed parent spawns; marker recording is skipped while replaying.
